### PR TITLE
Use "=a" to work around Clang's assembly handling

### DIFF
--- a/Code/TranslationUnits/Hardware/CPU/CPUIDPolicies/X64GCCAssemblyCPUIDPolicy.cpp
+++ b/Code/TranslationUnits/Hardware/CPU/CPUIDPolicies/X64GCCAssemblyCPUIDPolicy.cpp
@@ -14,16 +14,13 @@ namespace CPU
 		__asm__( R"(
 			cpuid
 		)"
-			: "=eax"( Registers.EAX ),
-			  "=ebx"( Registers.EBX ),
-			  "=ecx"( Registers.ECX ),
-			  "=edx"( Registers.EDX )
-			: "eax"( Leaf ),
-			  "ecx"( 0 )
-			: "rax",
-			  "rbx",
-			  "rcx",
-			  "rdx" );
+			: "=a"( Registers.EAX ),
+			  "=b"( Registers.EBX ),
+			  "=c"( Registers.ECX ),
+			  "=d"( Registers.EDX )
+			: "a"( Leaf ),
+			  "c"( 0 )
+			: );
 	}
 
 	void X64GCCAssemblyCPUIDPolicy::CPUIDExtended( CPUIDSubleafResult & Registers, uint32_t Leaf, uint32_t Subleaf ) noexcept
@@ -31,16 +28,13 @@ namespace CPU
 		__asm__( R"(
 			cpuid
 		)"
-			: "=eax"( Registers.EAX ),
-			  "=ebx"( Registers.EBX ),
-			  "=ecx"( Registers.ECX ),
-			  "=edx"( Registers.EDX )
-			: "eax"( Leaf ),
-			  "ecx"( Subleaf )
-			: "rax",
-			  "rbx",
-			  "rcx",
-			  "rdx" );
+			: "=a"( Registers.EAX ),
+			  "=b"( Registers.EBX ),
+			  "=c"( Registers.ECX ),
+			  "=d"( Registers.EDX )
+			: "a"( Leaf ),
+			  "c"( Subleaf )
+			:  );
 	}
 
 } // namespace CPU

--- a/Code/TranslationUnits/Hardware/CPU/CPUIDPolicies/X86GCCAssemblyCPUIDPolicy.cpp
+++ b/Code/TranslationUnits/Hardware/CPU/CPUIDPolicies/X86GCCAssemblyCPUIDPolicy.cpp
@@ -14,12 +14,12 @@ namespace CPU
 		__asm__( R"(
 			cpuid
 		)"
-			: "=eax"( Registers.EAX ),
-			  "=ebx"( Registers.EBX ),
-			  "=ecx"( Registers.ECX ),
-			  "=edx"( Registers.EDX )
-			: "eax"( Leaf ),
-			  "ecx"( 0 )
+			: "=a"( Registers.EAX ),
+			  "=b"( Registers.EBX ),
+			  "=c"( Registers.ECX ),
+			  "=d"( Registers.EDX )
+			: "a"( Leaf ),
+			  "c"( 0 )
 			: );
 	}
 
@@ -28,12 +28,12 @@ namespace CPU
 		__asm__( R"(
 			cpuid
 		)"
-			: "=eax"( Registers.EAX ),
-			  "=ebx"( Registers.EBX ),
-			  "=ecx"( Registers.ECX ),
-			  "=edx"( Registers.EDX )
-			: "eax"( Leaf ),
-			  "ecx"( Subleaf )
+			: "=a"( Registers.EAX ),
+			  "=b"( Registers.EBX ),
+			  "=c"( Registers.ECX ),
+			  "=d"( Registers.EDX )
+			: "a"( Leaf ),
+			  "c"( Subleaf )
 			: );
 	}
 

--- a/Code/TranslationUnits/Hardware/CPU/IsCPUIDAvailablePolicies/X64GCCAssemblyIsCPUIDAvailablePolicy.cpp
+++ b/Code/TranslationUnits/Hardware/CPU/IsCPUIDAvailablePolicies/X64GCCAssemblyIsCPUIDAvailablePolicy.cpp
@@ -12,32 +12,31 @@ namespace CPU
 
 	bool X64GCCAssemblyIsCPUIDAvailablePolicy::IsCPUIDAvailable() noexcept
 	{
-		uint32_t AlteredEFLAGS = UINT32_C( 0 );
+		uint64_t AlteredRFLAGS = UINT64_C( 0 );
 
 		__asm__( R"(
 			# Get the current RFLAGS register and set the ID bit
 
-			pushfq                     # Save the current RFLAGS register onto the stack
-			pop    %%rax               # Put the RFLAGS value in RAX
-			mov    %%rax,     %%rbx    # Save the value so we can later restore it
-			xor    $0x200000, %%rax    # Set the ID bit
-			push   %%rax               # Put the altered RFLAGS value back onto the stack
-			popfq                      # Restore the altered RFLAGS register
+			pushfq                                       # Save the current RFLAGS register onto the stack
+			pop    %[AlteredRFLAGS]                      # Put the RFLAGS value in RAX
+			mov    %[AlteredRFLAGS],  %%rbx              # Save the value so we can later restore it
+			xor    $0x200000,         %[AlteredRFLAGS]   # Set the ID bit
+			push   %[AlteredRFLAGS]                      # Put the altered RFLAGS value back onto the stack
+			popfq                                        # Restore the altered RFLAGS register
 
 
 			# Check if the altered RFLAGS register stuck
 
-			pushfq         # Save the new (possibly altered) RFLAGS register onto the stack
-			pop    %%rax   # Put the new RFLAGS value in RAX
-			push   %%rbx   # Put the original, unaltered RFLAGS back on the stack
-			popfq          # Put the original, unaltered RFLAGS back into the RFLAGS register
+			pushfq                    # Save the new (possibly altered) RFLAGS register onto the stack
+			pop    %[AlteredRFLAGS]   # Put the new RFLAGS value in RAX
+			push   %%rbx              # Put the original, unaltered RFLAGS back on the stack
+			popfq                     # Put the original, unaltered RFLAGS back into the RFLAGS register
 		)"
-			: "=eax"( AlteredEFLAGS )
+			: [AlteredRFLAGS] "=r" (AlteredRFLAGS)
 			:
-			: "rax",
-			  "rbx" );
+			: "rbx" );
 
-		return ( AlteredEFLAGS & 0x200000 ) == 0x200000;
+		return ( AlteredRFLAGS & 0x200000 ) == 0x200000;
 	}
 
 } // namespace CPUID

--- a/Code/TranslationUnits/Hardware/CPU/IsCPUIDAvailablePolicies/X86GCCAssemblyIsCPUIDAvailablePolicy.cpp
+++ b/Code/TranslationUnits/Hardware/CPU/IsCPUIDAvailablePolicies/X86GCCAssemblyIsCPUIDAvailablePolicy.cpp
@@ -17,24 +17,24 @@ namespace CPU
 		__asm__( R"(
 			# Get the current EFLAGS register and set the ID bit
 
-			pushfl                     # Save the current EFLAGS register onto the stack
-			pop    %%eax               # Put the EFLAGS value in EAX
-			mov    %%eax,     %%ebx    # Save the value so we can later restore it
-			xor    $0x200000, %%eax    # Set the ID bit
-			push   %%eax               # Put the altered EFLAGS value back onto the stack
-			popfl                      # Restore the altered EFLAGS register
+			pushfl                                       # Save the current EFLAGS register onto the stack
+			pop    %[AlteredEFLAGS]                      # Put the EFLAGS value in EAX
+			mov    %[AlteredEFLAGS],  %%ebx              # Save the value so we can later restore it
+			xor    $0x200000,         %[AlteredEFLAGS]   # Set the ID bit
+			push   %[AlteredEFLAGS]                      # Put the altered EFLAGS value back onto the stack
+			popfl                                        # Restore the altered EFLAGS register
 
 
 			# Check if the altered EFLAGS register stuck
 
-			pushfl         # Save the new (possibly altered) EFLAGS register onto the stack
-			pop    %%eax   # Put the new EFLAGS value in EAX
-			push   %%ebx   # Put the original, unaltered EFLAGS back on the stack
-			popfl          # Put the original, unaltered EFLAGS back into the EFLAGS register
+			pushfl                    # Save the new (possibly altered) EFLAGS register onto the stack
+			pop    %[AlteredEFLAGS]   # Put the new EFLAGS value in EAX
+			push   %%ebx              # Put the original, unaltered EFLAGS back on the stack
+			popfl                     # Put the original, unaltered EFLAGS back into the EFLAGS register
 		)"
-			: "=eax"( AlteredEFLAGS )
+			: [AlteredEFLAGS] "=r" (AlteredEFLAGS)
 			:
-			: "ebx" );
+			: "%ebx" );
 
 		return ( AlteredEFLAGS & 0x200000 ) == 0x200000;
 	}


### PR DESCRIPTION
GCC accepts "=eax" but Clang does not. As a result, Clang is
clobbering the results in eax.

BUG=50