### PR TITLE
Fix restricted pointer

### DIFF
--- a/Code/Include/max/Compiling/AliasingOptimizations.hpp
+++ b/Code/Include/max/Compiling/AliasingOptimizations.hpp
@@ -61,7 +61,7 @@
 // MAX_RESTRICTED_POINTER_V0
 // Documentation: ../../../../Documentation/max/v0/Compiling/MAX_RESTRICTED_POINTER.md
 #if defined( MAX_COMPILER_GCC )
-	#define MAX_RESTRICTED_POINTER_V0( Type ) __restrict__ Type
+	#define MAX_RESTRICTED_POINTER_V0( Type ) Type __restrict__
 #elif defined(MAX_COMPILER_VC)
 	#define MAX_RESTRICTED_POINTER_V0( Type ) Type __restrict
 #else


### PR DESCRIPTION
There was a mistake in the GCC implementation of the restricted
pointer. This CL fixes the mistake.