### PR TITLE
Fix and simplify aliasing optimization docs

### DIFF
--- a/Documentation/max/v0/Compiling/MAX_PURE.md
+++ b/Documentation/max/v0/Compiling/MAX_PURE.md
@@ -11,9 +11,13 @@ A pure function is one that references or modifies only locals and arguments.
 It cannot follow first-level indirections. This means no pointers or references.
 A pure function also cannot access globals.
 
-Use [MAX_PURE_WITH_GLOBALS](MAX_PURE_WITH_GLOBALS.md) instead if the code needs to access globals.
+MAX_PURE should not be used on methods / member functions.
+Methods have a hidden 'this' first parameter. Accessing a field / member variable happens through the 'this' pointer, which is a first-level indirection. This goes against the idea of MAX_PURE.
+MAX_PURE only applies to static methods and free functions.
 
 Use [MAX_SEMI_PURE](MAX_SEMI_PURE.md) instead if the code needs to follow first-level indirections.
+
+Use [MAX_PURE_WITH_GLOBALS](MAX_PURE_WITH_GLOBALS.md) instead if the code needs to access globals.
 
 ## Example
 

--- a/Documentation/max/v0/Compiling/MAX_PURE_WITH_GLOBALS.md
+++ b/Documentation/max/v0/Compiling/MAX_PURE_WITH_GLOBALS.md
@@ -22,7 +22,6 @@ int gTotalTime = 0;
 
 MAX_PURE_WITH_GLOBALS_DECLARATION( void UpdateGlobalStats( int ElapsedTicks ) );
 
-template< typename T >
 MAX_PURE_WITH_GLOBALS_DEFINITION( void UpdateGlobalStats( int ElapsedTicks ) )
 {
 	gTotalTime += ElapsedTicks;

--- a/Documentation/max/v0/Compiling/MAX_RESTRICTED_REFERENCE.md
+++ b/Documentation/max/v0/Compiling/MAX_RESTRICTED_REFERENCE.md
@@ -19,4 +19,4 @@ void Consume( MAX_RESTRICTED_REFERENCE( int & ) value );
 
 ## Implementation
 
-Go to [the implementation](../../../../Code/Include/max/Containers/Range.inl#L72).
+Go to [the implementation](../../../../Code/Include/max/Compiling/AliasingOptimizations.hpp#L72).

--- a/Documentation/max/v0/Compiling/MAX_RETURNS_RESTRICTED_POINTER.md
+++ b/Documentation/max/v0/Compiling/MAX_RETURNS_RESTRICTED_POINTER.md
@@ -17,4 +17,4 @@ MAX_RETURNS_RESTRICTED_POINTER void * malloc( size_t size );
 
 ## Implementation
 
-Go to [the implementation](../../../../Code/Include/max/Containers/Range.inl#L87).
+Go to [the implementation](../../../../Code/Include/max/Compiling/AliasingOptimizations.hpp#L87).

--- a/Documentation/max/v0/Compiling/MAX_SEMI_PURE.md
+++ b/Documentation/max/v0/Compiling/MAX_SEMI_PURE.md
@@ -12,7 +12,8 @@ This means param1->foo is okay.
 But param1->member1->foo isn't okay. This is a second-level indirection.
 A semi-pure function also cannot access globals.
 
-Note that member functions which reference member variables are following a first-level indirection.
+Methods / member functions which reference fields / member variables are following a first-level indirection via the 'this' pointer.
+So member1->foo isn't okay but simply accessing member1 is okay.
 
 Use [MAX_PURE](MAX_PURE.md) instead if the code does not need to follow first-level indirections.
 


### PR DESCRIPTION
There were 2 errors in the aliasing optimization docs.
Links to the implementation were wrong. These have been fixed.

Additionally, extra wording was added to clarify that the hidden
'this' parameter is used to access member variables and thus
incurs a first-level indirection.

Issue #37 