### PR TITLE
Update MAX_PURE docs with new style. Fix typo.

### DIFF
--- a/Documentation/max/v0/Compiling/MAX_PURE.md
+++ b/Documentation/max/v0/Compiling/MAX_PURE.md
@@ -23,7 +23,15 @@ Use [MAX_PURE_WITH_GLOBALS](MAX_PURE_WITH_GLOBALS.md) instead if the code needs 
 
 ```c++
 template< typename T >
-MAX_PURE( inline T Max( const T lhs, const T rhs ) );
+MAX_PURE_DECLARATION( inline T Max( const T lhs, const T rhs ) );
+
+template< typename T >
+MAX_PURE_DEFINITION( inline T Max( const T lhs, const T rhs ) )
+{
+	if ( lhs >= rhs )
+		return lhs;
+	return rhs;
+}
 ```
 
 ## Implementation

--- a/Documentation/max/v0/Compiling/MAX_SEMI_PURE.md
+++ b/Documentation/max/v0/Compiling/MAX_SEMI_PURE.md
@@ -28,7 +28,7 @@ MAX_SEMI_PURE_DECLARATION( T Max( const T & lhs, const T & rhs ) );
 template< typename T >
 MAX_SEMI_PURE_DEFINITION( T Max( const T & lhs, const T & rhs ) )
 {
-	if (lhs >= rhs )
+	if ( lhs >= rhs )
 		return lhs;
 	return rhs;
 }


### PR DESCRIPTION
There was a typo in MAX_SEMI_PURE.md which has been fixed.

Also, MAX_PURE.md doesn't talk about the new macros for
declaration and definition. This has been fixed.