### PR TITLE
Upload test suite results to AppVeyor

### DIFF
--- a/Tooling/AppVeyor/AppVeyor.yml
+++ b/Tooling/AppVeyor/AppVeyor.yml
@@ -26,6 +26,6 @@ configuration:
   - Release
 
 test_script:
-  #- "%APPVEYOR_BUILD_FOLDER%/Projects/VisualStudio/maxAutomatedTests/Win32/Debug/maxAutomatedTests.exe"
-  - echo "%APPVEYOR_BUILD_FOLDER%/Projects/VisualStudio/maxAutomatedTests/%PLATFORM%/%CONFIGURATION%/maxAutomatedTests.exe"
   - "%APPVEYOR_BUILD_FOLDER%/Projects/VisualStudio/maxAutomatedTests/%PLATFORM%/%CONFIGURATION%/maxAutomatedTests.exe"
+  - ps: $wc = New-Object 'System.Net.WebClient'
+  - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\Tooling\AppVeyor\junit-results.xml))

--- a/Tooling/AppVeyor/junit-results.xml
+++ b/Tooling/AppVeyor/junit-results.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>
+	<testsuite name="example suite">
+		<testcase name="example case">
+		</testcase>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
The tests were previously being run but their results were not being
displayed in AppVeyor. Displaying those results requires saving the
results to a xml file and uploading it to AppVeyor, using a known
format and a per-run destination URL.

This commit adds the capabiliy to display test results in AppVeyor.