### PR TITLE
Add good-first-task link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ As an example, when a new version of Clang comes out you will have 5 years to mi
 ## Engage
 
 * **Community:** We have a welcoming community which follows the [Code of Conduct](/code_of_conduct.md).
-* **Contribute:** We accept pull requests. Take a look at the [good first tasks](https://github.com/ProgramMax/max/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-task)
+* **Contribute:** We accept pull requests. Take a look at some [good first tasks](https://github.com/ProgramMax/max/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-task).
 * **Support:** You can report bugs and request changes using GitHub issues.
 
 [travis-shield]: https://travis-ci.org/ProgramMax/max.svg?branch=master


### PR DESCRIPTION
The README.md suggests that people contribute. But it doesn't let
them know how they can contribute.

This commit adds a link to the issues marked as good-first-task
to README.md.