### PR TITLE
Consolidate supported platforms in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ It includes common code such as logging, testing, abstractions for compiler and 
 
 ## Support
 
-Currently, max supports:
-
 * Compilers:
     * GCC
     * Clang
@@ -22,17 +20,13 @@ Currently, max supports:
 * OSes:
     * Some POSIX Linux (can't test them all)
     * Windows
+    * MacOS*
+    * Android*
+    * iOS*
 * Instruction sets:
     * x86 (64)
-
-In the future, max will also support:
-
-* OSes:
-    * MacOS
-    * Android
-    * iOS
-* Instruction sets:
-    * ARM
+    * ARM*
+*Coming soon
 
 If you would like max to support more contacts us and let us know.
 


### PR DESCRIPTION
There were previously 2 separate sections for the currently-
supported platforms and the soon-to-be-supported platforms. They
appeared bulky when viewing README.md.

This commit consolidates the 2 platform sections into 1, with a
marker for soon-to-be-supported platforms.