### PR TITLE
Fix typo & remove similie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # max
 
-max is like a toolbelt for C++.
+max is a tool belt for C++.
 
 It includes common code such as logging, testing, abstractions for compiler and platform specific APIs (like endian conversion and CPU feature detection), and much more.
 


### PR DESCRIPTION
README.md previously read "max is like a toolbelt for C++."
Tool belt is 2 words. And rather than use a similie we could just
say it is.

This commit fixes those two issues.