### PR TITLE
Fix Code of Conduct link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ As an example, when a new version of Clang comes out you will have 5 years to mi
 
 ## Engage
 
-* **Community:** We have a welcoming community which follows the [Code of Conduct](/code_of_conduct.md).
+* **Community:** We have a welcoming community which follows the [Code of Conduct](code_of_conduct.md).
 * **Contribute:** We accept pull requests. Take a look at some [good first tasks](https://github.com/ProgramMax/max/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-task).
 * **Support:** You can report bugs and request changes using GitHub issues.
 


### PR DESCRIPTION
README.md linked to /code_of_conduct.md. Now that README.md is no
longer in the root directory, change the link to reflect this.

This commit changes the link to the relative code_of_conduct.md.