### PR TITLE
Remove Bit16.cpp from VS project

### DIFF
--- a/Projects/VisualStudio/max/max.vcxproj
+++ b/Projects/VisualStudio/max/max.vcxproj
@@ -105,7 +105,6 @@
     <ClInclude Include="..\..\..\Code\Include\max\Testing\TestSuite.hpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\Code\Include\max\Containers\Bits16.cpp" />
     <ClCompile Include="..\..\..\Code\TranslationUnits\Hardware\CPU\Associativity.cpp" />
     <ClCompile Include="..\..\..\Code\TranslationUnits\Hardware\CPU\CacheInfo.cpp" />
     <ClCompile Include="..\..\..\Code\TranslationUnits\Hardware\CPU\CacheLevel.cpp" />

--- a/Projects/VisualStudio/max/max.vcxproj.filters
+++ b/Projects/VisualStudio/max/max.vcxproj.filters
@@ -368,9 +368,6 @@
     <ClCompile Include="..\..\..\Code\TranslationUnits\Hardware\CPU\TraceCache.cpp">
       <Filter>Code\TranslationUnits\Hardware\CPU</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\Code\Include\max\Containers\Bits16.cpp">
-      <Filter>Code\Include\max\Containers</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\Code\TranslationUnits\Hardware\CPU\CPUIDPolicies\AssemblyCPUIDPolicy.cpp">
       <Filter>Code\TranslationUnits\Hardware\CPU\CPUIDPolicies</Filter>
     </ClCompile>


### PR DESCRIPTION
Bits16.cpp was previously removed. However, the VS
project still referenced it.

This commit removes Bits16.cpp from the VS project.