### PR TITLE
Add links to bug reports & feature requests

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -43,7 +43,7 @@ As an example, when a new version of Clang comes out you will have 5 years to mi
 
 * **Community:** We have a welcoming community which follows the [Code of Conduct](code_of_conduct.md).
 * **Contribute:** We accept pull requests. Take a look at some [good first tasks](https://github.com/ProgramMax/max/issues?q=is%3Aissue+is%3Aopen+label%3A"good+first+issue").
-* **Support:** You can report bugs and request changes using GitHub issues.
+* **Support:** You can [report bugs](https://github.com/ProgramMax/max/issues/new?assignees=&labels=&template=bug_report.md&title=) and [request changes](https://github.com/ProgramMax/max/issues/new?assignees=&labels=&template=feature_request.md&title=) using GitHub issues.
 
 [travis-shield]: https://travis-ci.org/ProgramMax/max.svg?branch=master
 [travis-link]: https://travis-ci.org/ProgramMax/max/builds


### PR DESCRIPTION
README.md mentions the ability to use GitHub issues for both bug
reports and feature requests. However, it would be easier for users
if we just linked to those things.

This commit adds links to those in README.md.