### PR TITLE
Fix build error with CoutResultPolicy.cpp

### DIFF
--- a/Code/TranslationUnits/Testing/CoutResultPolicy.cpp
+++ b/Code/TranslationUnits/Testing/CoutResultPolicy.cpp
@@ -54,7 +54,7 @@ namespace Testing
 		std::cout << "Tearing down test suite " << TestSuiteName << "." << std::endl;
 	}
 
-	void CoutResultPolicy::OnTestSuiteDone( char const * const TestSuiteName,
+	void CoutResultPolicy::OnTestSuiteDone( std::string const & TestSuiteName,
 	                                        int TestsPassed,
 	                                        int TestsFailed )
 	{


### PR DESCRIPTION
There was an error where a .hpp and .cpp file had different
function signatures.

This commit fixes the build error by bringing the function
signatures together.