### PR TITLE
Remove TravisCI

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -4,7 +4,7 @@ max is a tool belt for C++.
 
 It includes common code such as logging, testing, abstractions for compiler and platform specific APIs (like endian conversion and CPU feature detection), and much more.
 
-[![Travis CI status][travis-shield]][travis-link]
+<!-- [![Travis CI status][travis-shield]][travis-link] -->
 [![AppVeyor CI status][appveyor-shield]][appveyor-link]
 
 ## Features


### PR DESCRIPTION
TravisCI requires permissions that grant too much access.
As a result, I cannot use TravisCI.

Until this is resolved on TravisCI's end, we'll just disable it here.