### PR TITLE
Add deprecation schedule

### DIFF
--- a/Docs/DeprecationSchedule.md
+++ b/Docs/DeprecationSchedule.md
@@ -1,0 +1,61 @@
+# max deprecation schedule
+
+|Clang version|Release date|max deprecation date|
+|-------------|-----------:|-------------------:|
+|Clang 7.0.x  |Sep 19, 2018|             Current|
+|Clang 6.0.x  |Mar  8, 2018|        Sep 19, 2023|
+|Clang 5.0.x  |Sep  7, 2018|        Mar  8, 2023|
+|Clang 4.0.x  |Mar 13, 2017|        Sep  7, 2023|
+|Clang 3.9.x  |Sep  2, 2016|        Mar 13, 2022|
+|Clang 3.8.x  |Mar  8, 2016|        Sep  2, 2021|
+|Clang 3.7.x  |Sep  1, 2015|        Mar  8, 2021|
+|Clang 3.6.x  |Feb 27, 2015|        Sep  1, 2020|
+|Clang 3.5.x  |Sep  3, 2014|        Feb 27, 2020|
+|Clang 3.4.x  |Jan  2, 2014|        Sep  3, 2029|
+|Clang 3.3    |Jun 17, 2013|        Jan  2, 2019|
+|Clang 3.2    |Dec 20, 2012|          Deprecated|
+
+|GCC version|Release date|max deprecation date|
+|-----------|-----------:|-------------------:|
+|GCC 8.2    |Jul 26, 2018|             Current|
+|GCC 7.3    |Jan 25, 2018|        Jul 26, 2023|
+|GCC 7.2    |Aug 14, 2017|        Jan 25, 2023|
+|GCC 7.1    |May  2, 2017|        Aug 14, 2023|
+|GCC 6.3    |Dec 21, 2016|        May  2, 2022|
+|GCC 6.2    |Aug 22, 2016|        Dec 21, 2021|
+|GCC 6.1    |Apr 27, 2016|        Aug 22, 2021|
+|GCC 5.3    |Dec  4, 2015|        Apr 27, 2021|
+|GCC 5.2    |Jul 16, 2015|        Dec  4, 2020|
+|GCC 5.1    |Apr 22, 2015|        Jul 16, 2020|
+|GCC 4.9.x  |Apr 22, 2014|        Apr 22, 2020|
+|GCC 4.8.x  |Mar 22, 2013|        Apr 22, 2019|
+|GCC 4.7.x  |Mar 22, 2012|          Deprecated|
+
+|MSVC version      |Release date|max deprecation date|
+|------------------|-----------:|-------------------:|
+|MSVC 15.9.x       |Nov 13, 2018|             Current|
+|MSVC 15.8.x       |Aug 14, 2018|        Nov 13, 2023|
+|MSVC 15.7.x       |May  7, 2018|        Aug 14, 2023|
+|MSVC 15.6.x       |Mar  5, 2018|        May  7, 2023|
+|MSVC 15.5.x       |Dec  4, 2017|        Mar  5, 2023|
+|MSVC 15.4.x       |Oct  9, 2017|        Dec  4, 2022|
+|MSVC 15.3.x       |Aug 14, 2017|        Oct  9, 2022|
+|MSVC 15.2.x       |May 10, 2017|        Aug 14, 2022|
+|MSVC 15.1.x       |Apr  5, 2017|        May 10, 2022|
+|MSVC 15.0.x       |Mar  7, 2017|        Apr  5, 2022|
+|MSVC 2015 Update 3|Jun 27, 2016|        Mar  7, 2022|
+|MSVC 2015 Update 2|Mar 30, 2016|        Jun 27, 2021|
+|MSVC 2015 Update 1|Nov 30, 2015|        Mar 30, 2021|
+|MSVC 2015         |Jul 20, 2015|        Nov 30, 2020|
+|MSVC 2013 Update 4|Nov 12, 2014|        Jul 20, 2020|
+|MSVC 2013 Update 3|Aug  4, 2014|        Nov 12, 2019|
+|MSVC 2013 Update 2|Apr  2, 2014|        Aug  4, 2019|
+|MSVC 2013 Update 1|Jan 20, 2014|        Apr  2, 2019|
+|MSVC 2013         |Oct 17, 2013|        Jan 20, 2019|
+|MSVC 2012 Update 4|Nov 13, 2013|          Deprecated|
+
+|Windows version|Release date|max deprecation date|
+|---------------|-----------:|-------------------:|
+|Windows 10     |Jul 29, 2015|             Current|
+|Windows 8.1    |Oct 17, 2013|        Jul 29, 2020|
+|Windows 8      |Oct 26, 2012|          Deprecated|

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -39,6 +39,8 @@ In order to ease transition pressure, max will continue to provide support for 5
 
 As an example, when a new version of Clang comes out you will have 5 years to migrate off the now-old version.
 
+You can reference the [deprecation schedule](DeprecationSchedule.md) for exact dates.
+
 ## Engage
 
 * **Community:** We have a welcoming community which follows the [Code of Conduct](code_of_conduct.md).


### PR DESCRIPTION
It would be helpful for both users and us to list out dates when
each piece becomes deprecated. It is a little unclear for people
to calculate.

This commit adds a deprecation schedule and links to it from
README.md