### PR TITLE
Create macros for compile time messages

### DIFF
--- a/Code/Include/max/Compiling/Configuration/Compiler/Clang.hpp
+++ b/Code/Include/max/Compiling/Configuration/Compiler/Clang.hpp
@@ -9,7 +9,7 @@
 
 #define MAX_COMPILER_CLANG
 
-#define MAX_INFORMATION(Message) _Pragma(MAX_STRINGIFY2(message(Message)))
+#define MAX_COMPILER_MESSAGE(Message) _Pragma(MAX_STRINGIFY(message(Message)))
 
 #define MAX_COMPILER_VERSION_MAJOR __clang_major__
 #define MAX_COMPILER_VERSION_MINOR __clang_minor__

--- a/Code/Include/max/Compiling/Configuration/Compiler/Clang.hpp
+++ b/Code/Include/max/Compiling/Configuration/Compiler/Clang.hpp
@@ -5,13 +5,11 @@
 #ifndef MAX_COMPILING_CONFIGURATION_COMPILER_CLANG_HPP
 #define MAX_COMPILING_CONFIGURATION_COMPILER_CLANG_HPP
 
+#include <max/Compiling/Macros.hpp>
 
 #define MAX_COMPILER_CLANG
 
-#define MAX_DO_PRAGMA(x) _Pragma (#x)
-#define MAX_INFORMATION(Message) MAX_DO_PRAGMA(message(Message))
-#define MAX_WARNING(Message) MAX_DO_PRAGMA(warning(Message))
-#define MAX_ERROR(Message) MAX_DO_PRAGMA(error(Message))
+#define MAX_INFORMATION(Message) _Pragma(MAX_STRINGIFY2(message(Message)))
 
 #define MAX_COMPILER_VERSION_MAJOR __clang_major__
 #define MAX_COMPILER_VERSION_MINOR __clang_minor__

--- a/Code/Include/max/Compiling/Configuration/Compiler/Clang.hpp
+++ b/Code/Include/max/Compiling/Configuration/Compiler/Clang.hpp
@@ -7,6 +7,12 @@
 
 
 #define MAX_COMPILER_CLANG
+
+#define MAX_DO_PRAGMA(x) _Pragma (#x)
+#define MAX_INFORMATION(Message) MAX_DO_PRAGMA(message(Message))
+#define MAX_WARNING(Message) MAX_DO_PRAGMA(warning(Message))
+#define MAX_ERROR(Message) MAX_DO_PRAGMA(error(Message))
+
 #define MAX_COMPILER_VERSION_MAJOR __clang_major__
 #define MAX_COMPILER_VERSION_MINOR __clang_minor__
 #define MAX_COMPILER_VERSION_PATCH __clang_patchlevel__

--- a/Code/Include/max/Compiling/Configuration/Compiler/GCC.hpp
+++ b/Code/Include/max/Compiling/Configuration/Compiler/GCC.hpp
@@ -7,6 +7,12 @@
 
 
 #define MAX_COMPILER_GCC
+
+#define MAX_DO_PRAGMA(x) _Pragma (#x)
+#define MAX_INFORMATION(Message) MAX_DO_PRAGMA(message(Message))
+#define MAX_WARNING(Message) MAX_DO_PRAGMA(warning(Message))
+#define MAX_ERROR(Message) MAX_DO_PRAGMA(error(Message))
+
 #define MAX_COMPILER_VERSION_MAJOR __GNUC__
 #define MAX_COMPILER_VERSION_MINOR __GNUC_MINOR__
 #if __GNUC__ >= 3

--- a/Code/Include/max/Compiling/Configuration/Compiler/GCC.hpp
+++ b/Code/Include/max/Compiling/Configuration/Compiler/GCC.hpp
@@ -10,7 +10,7 @@
 
 #define MAX_COMPILER_GCC
 
-#define MAX_INFORMATION(Message) _Pragma(MAX_STRINGIFY2(message(Message)))
+#define MAX_COMPILER_MESSAGE(Message) _Pragma(MAX_STRINGIFY(message(Message)))
 
 #define MAX_COMPILER_VERSION_MAJOR __GNUC__
 #define MAX_COMPILER_VERSION_MINOR __GNUC_MINOR__

--- a/Code/Include/max/Compiling/Configuration/Compiler/GCC.hpp
+++ b/Code/Include/max/Compiling/Configuration/Compiler/GCC.hpp
@@ -6,12 +6,11 @@
 #define MAX_COMPILING_CONFIGURATION_COMPILER_GCC_HPP
 
 
+#include <max/Compiling/Macros.hpp>
+
 #define MAX_COMPILER_GCC
 
-#define MAX_DO_PRAGMA(x) _Pragma (#x)
-#define MAX_INFORMATION(Message) MAX_DO_PRAGMA(message(Message))
-#define MAX_WARNING(Message) MAX_DO_PRAGMA(warning(Message))
-#define MAX_ERROR(Message) MAX_DO_PRAGMA(error(Message))
+#define MAX_INFORMATION(Message) _Pragma(MAX_STRINGIFY2(message(Message)))
 
 #define MAX_COMPILER_VERSION_MAJOR __GNUC__
 #define MAX_COMPILER_VERSION_MINOR __GNUC_MINOR__

--- a/Code/Include/max/Compiling/Configuration/Compiler/VC.hpp
+++ b/Code/Include/max/Compiling/Configuration/Compiler/VC.hpp
@@ -6,6 +6,13 @@
 #define MAX_COMPILING_CONFIGURATION_COMPILER_VC_HPP
 
 #define MAX_COMPILER_VC
+
+#define MAX_INFORMATION(Message) __pragma(message(Message))
+// MSVC doesn't support custom warning messages.
+// Favor the more harsh error over information which could be missed.
+#define MAX_WARNING(Message) static_assert(false, Message)
+#define MAX_ERROR(Message) static_assert(false, Message)
+
 #if _MSC_VER == 1913
 	// VC 15.6 (2017)
 	#define MAX_COMPILER_VERSION_MAJOR 15

--- a/Code/Include/max/Compiling/Configuration/Compiler/VC.hpp
+++ b/Code/Include/max/Compiling/Configuration/Compiler/VC.hpp
@@ -7,7 +7,7 @@
 
 #define MAX_COMPILER_VC
 
-#define MAX_INFORMATION(Message) __pragma(message(Message))
+#define MAX_COMPILER_MESSAGE(Message) __pragma(message(Message))
 
 #if _MSC_VER == 1913
 	// VC 15.6 (2017)

--- a/Code/Include/max/Compiling/Configuration/Compiler/VC.hpp
+++ b/Code/Include/max/Compiling/Configuration/Compiler/VC.hpp
@@ -8,10 +8,6 @@
 #define MAX_COMPILER_VC
 
 #define MAX_INFORMATION(Message) __pragma(message(Message))
-// MSVC doesn't support custom warning messages.
-// Favor the more harsh error over information which could be missed.
-#define MAX_WARNING(Message) static_assert(false, Message)
-#define MAX_ERROR(Message) static_assert(false, Message)
 
 #if _MSC_VER == 1913
 	// VC 15.6 (2017)

--- a/Code/Include/max/Compiling/Macros.hpp
+++ b/Code/Include/max/Compiling/Macros.hpp
@@ -6,8 +6,10 @@
 #define MAX_COMPILING_MACROS_HPP
 
 
-#define MAX_STRINGIFY2(Message) #Message
-#define MAX_STRINGIFY(Message) MAX_STRINGIFY2(Message)
+// Documentation: ../../../../Docs/max/v0/Compiling/Macros.md
+
+#define MAX_STRINGIFY(Message) #Message
+#define MAX_EXPAND_AND_STRINGIFY(Message) MAX_STRINGIFY(Message)
 
 
 #endif // #ifndef MAX_COMPILING_MACROS_HPP

--- a/Code/Include/max/Compiling/Macros.hpp
+++ b/Code/Include/max/Compiling/Macros.hpp
@@ -1,0 +1,13 @@
+// Copyright 2019, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_COMPILING_MACROS_HPP
+#define MAX_COMPILING_MACROS_HPP
+
+
+#define MAX_STRINGIFY2(Message) #Message
+#define MAX_STRINGIFY(Message) MAX_STRINGIFY2(Message)
+
+
+#endif // #ifndef MAX_COMPILING_MACROS_HPP

--- a/Code/ManualTests/ConfigurationTest.cpp
+++ b/Code/ManualTests/ConfigurationTest.cpp
@@ -1,0 +1,21 @@
+// Copyright 2019, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ConfigurationTest.hpp"
+#include <max/Compiling/Configuration.hpp>
+#include <max/Compiling/Macros.hpp>
+
+namespace maxManualTests
+{
+	namespace Compiling
+	{
+
+		void RunConfigurationTestSuite()
+		{
+			MAX_COMPILER_MESSAGE("MAX_MESSAGE works");
+			MAX_COMPILER_MESSAGE("And you can include other defines like __LINE__: " MAX_EXPAND_AND_STRINGIFY(__LINE__));
+		}
+
+	} // namespace Compiling
+} // namespace maxManualTests

--- a/Code/ManualTests/ConfigurationTest.hpp
+++ b/Code/ManualTests/ConfigurationTest.hpp
@@ -1,0 +1,18 @@
+// Copyright 2019, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAXMANUALTESTS_COMPILING_CONFIGURATIONTEST_HPP
+#define MAXMANUALTESTS_COMPILING_CONFIGURATIONTEST_HPP
+
+namespace maxManualTests
+{
+	namespace Compiling
+	{
+
+		void RunConfigurationTestSuite();
+
+	} // namespace Compiling
+} // namespace maxManualTests
+
+#endif // #ifndef MAXMANUALTESTS_COMPILING_CONFIGURATIONTEST_HPP

--- a/Code/ManualTests/EntryPoint.cpp
+++ b/Code/ManualTests/EntryPoint.cpp
@@ -3,11 +3,13 @@
 // found in the LICENSE file.
 
 #include "AliasingOptimizationsTest.hpp"
+#include "ConfigurationTest.hpp"
 
 int main()
 {
 
 	maxManualTests::Compiling::RunAliasingOptimizationsTestSuite();
-	
+	maxManualTests::Compiling::RunConfigurationTestSuite();
+
 	return 0;
 }

--- a/Docs/max/v0/Compiling/MAX_COMPILER_MESSAGE.md
+++ b/Docs/max/v0/Compiling/MAX_COMPILER_MESSAGE.md
@@ -1,0 +1,17 @@
+# MAX_COMPILER_MESSAGE
+
+API version: [**v0**](../../v0.md)
+
+## Note
+
+MAX_COMPILER_MESSAGE allows a programmer to print a message during compilation.
+
+## Example
+
+```c++
+MAX_COMPILER_MESSAGE("Perhaps warn the user that some code is deprecated");
+```
+
+## Implementation
+
+Go to the separate implementations for [Clang](../../../../Code/Include/max/Compiling/Configuration/Compiler/Clang.hpp#L12), [GCC](../../../../Code/Include/max/Compiling/Configuration/Compiler/Clang.hpp#L13), and [MSVC](../../../../Code/Include/max/Compiling/Configuration/Compiler/Clang.hpp#L10).

--- a/Docs/max/v0/Compiling/Macros.md
+++ b/Docs/max/v0/Compiling/Macros.md
@@ -1,0 +1,22 @@
+# MAX_STRINGIFY and MAX_EXPAND_AND_STRINGIFY
+
+API version: [**v0**](../../v0.md)
+
+## Note
+
+MAX_STRINGIFY and MAX_EXPAND_AND_STRINGIFY are both used to get a string representation of a macro parameter.
+
+MAX_STRINGIFY produces the name of the parameter.
+
+MAX_EXPAND_AND_STRINGIFY will evaluate the macro parameter's contents and produce a string representation of that.
+
+## Example
+
+```c++
+MAX_COMPILER_MESSAGE(MAX_STRINGIFY(__LINE__) " has the value " MAX_EXPAND_AND_STRINGIFY(__LINE__));
+// Prints "__LINE__ has the value 1"
+```
+
+## Implementation
+
+Go to [the implementation](../../../../Code/Include/max/Compiling/Macros.hpp#L11).

--- a/Projects/VisualStudio/max/max.vcxproj
+++ b/Projects/VisualStudio/max/max.vcxproj
@@ -33,19 +33,24 @@
     <None Include="..\..\..\Code\Include\max\Testing\Test.inl" />
     <None Include="..\..\..\Code\Include\max\Testing\TestSuite.inl" />
     <None Include="..\..\..\Code\TranslationUnits\Hardware\CPU\IsCPUIDAvailablePolicies\Documentation.md" />
-    <None Include="..\..\..\Documentation\max\v0.md" />
-    <None Include="..\..\..\Documentation\max\v0\Algorithms\IsBetween.md" />
-    <None Include="..\..\..\Documentation\max\v0\Compiling\AliasingOptimizations.md" />
-    <None Include="..\..\..\Documentation\max\v0\Compiling\MAX_PURE.md" />
-    <None Include="..\..\..\Documentation\max\v0\Compiling\MAX_PURE_WITH_GLOBALS.md" />
-    <None Include="..\..\..\Documentation\max\v0\Compiling\MAX_RESTRICTED_POINTER.md" />
-    <None Include="..\..\..\Documentation\max\v0\Compiling\MAX_RESTRICTED_REFERENCE.md" />
-    <None Include="..\..\..\Documentation\max\v0\Compiling\MAX_RETURNS_RESTRICTED_POINTER.md" />
-    <None Include="..\..\..\Documentation\max\v0\Compiling\MAX_SEMI_PURE.md" />
-    <None Include="..\..\..\Documentation\max\v0\Containers\MakeRange.md" />
-    <None Include="..\..\..\Documentation\max\v0\Containers\Range.md" />
-    <None Include="..\..\..\Documentation\max\v0\Containers\Range_ctor.md" />
-    <None Include="..\..\..\Documentation\StyleGuide.md" />
+    <None Include="..\..\..\Docs\code_of_conduct.md" />
+    <None Include="..\..\..\Docs\DeprecationSchedule.md" />
+    <None Include="..\..\..\Docs\max\v0.md" />
+    <None Include="..\..\..\Docs\max\v0\Algorithms\IsBetween.md" />
+    <None Include="..\..\..\Docs\max\v0\Compiling\AliasingOptimizations.md" />
+    <None Include="..\..\..\Docs\max\v0\Compiling\MAX_COMPILER_MESSAGE.md" />
+    <None Include="..\..\..\Docs\max\v0\Compiling\Macros.md" />
+    <None Include="..\..\..\Docs\max\v0\Compiling\MAX_PURE.md" />
+    <None Include="..\..\..\Docs\max\v0\Compiling\MAX_PURE_WITH_GLOBALS.md" />
+    <None Include="..\..\..\Docs\max\v0\Compiling\MAX_RESTRICTED_POINTER.md" />
+    <None Include="..\..\..\Docs\max\v0\Compiling\MAX_RESTRICTED_REFERENCE.md" />
+    <None Include="..\..\..\Docs\max\v0\Compiling\MAX_RETURNS_RESTRICTED_POINTER.md" />
+    <None Include="..\..\..\Docs\max\v0\Compiling\MAX_SEMI_PURE.md" />
+    <None Include="..\..\..\Docs\max\v0\Containers\MakeRange.md" />
+    <None Include="..\..\..\Docs\max\v0\Containers\Range.md" />
+    <None Include="..\..\..\Docs\max\v0\Containers\Range_ctor.md" />
+    <None Include="..\..\..\Docs\README.md" />
+    <None Include="..\..\..\Docs\StyleGuide.md" />
     <None Include="..\..\..\LICENSE" />
   </ItemGroup>
   <ItemGroup>
@@ -73,6 +78,7 @@
     <ClInclude Include="..\..\..\Code\Include\max\Compiling\FavorBranchLocality.hpp" />
     <ClInclude Include="..\..\..\Code\Include\max\Compiling\IsRegular.hpp" />
     <ClInclude Include="..\..\..\Code\Include\max\Compiling\Loop.hpp" />
+    <ClInclude Include="..\..\..\Code\Include\max\Compiling\Macros.hpp" />
     <ClInclude Include="..\..\..\Code\Include\max\Compiling\MemoryBarrier.hpp" />
     <ClInclude Include="..\..\..\Code\Include\max\Compiling\NoDefault.hpp" />
     <ClInclude Include="..\..\..\Code\Include\max\Compiling\StaticAssert.hpp" />

--- a/Projects/VisualStudio/max/max.vcxproj.filters
+++ b/Projects/VisualStudio/max/max.vcxproj.filters
@@ -1,9 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Documentation">
-      <UniqueIdentifier>{4c7c656f-4470-4128-82ed-47a0684591d2}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Code">
       <UniqueIdentifier>{d2123baa-7920-4f49-b290-6d7dc9d9a7fb}</UniqueIdentifier>
     </Filter>
@@ -55,21 +52,6 @@
     <Filter Include="Code\TranslationUnits\Hardware\CPU">
       <UniqueIdentifier>{70481055-44ea-4c30-874f-98f6284c1f71}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Documentation\max">
-      <UniqueIdentifier>{7537fa1e-d771-4a81-84f1-c8e09f24fba0}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Documentation\max\v0">
-      <UniqueIdentifier>{f7b357b5-721d-4bec-8443-b6182a1fd974}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Documentation\max\v0\Containers">
-      <UniqueIdentifier>{02e79c1a-a9dc-42f6-91ea-66de4f005068}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Documentation\max\v0\Algorithms">
-      <UniqueIdentifier>{b10e5494-b7eb-49a0-8b13-064f9ea93fb7}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Documentation\max\v0\Compiling">
-      <UniqueIdentifier>{c79a2bc5-4845-4128-8999-f4ae5cf4ca9e}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Code\Include\max\Containers">
       <UniqueIdentifier>{71aa0028-8a13-455b-8cd1-e5dcec8cb389}</UniqueIdentifier>
     </Filter>
@@ -84,6 +66,24 @@
     </Filter>
     <Filter Include="Code\TranslationUnits\Hardware\CPU\CPUIDPolicies">
       <UniqueIdentifier>{a2f67fcd-70e1-4176-a3c8-30e6fa0d5df4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Docs">
+      <UniqueIdentifier>{4c7c656f-4470-4128-82ed-47a0684591d2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Docs\max">
+      <UniqueIdentifier>{7537fa1e-d771-4a81-84f1-c8e09f24fba0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Docs\max\v0">
+      <UniqueIdentifier>{f7b357b5-721d-4bec-8443-b6182a1fd974}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Docs\max\v0\Containers">
+      <UniqueIdentifier>{02e79c1a-a9dc-42f6-91ea-66de4f005068}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Docs\max\v0\Algorithms">
+      <UniqueIdentifier>{b10e5494-b7eb-49a0-8b13-064f9ea93fb7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Docs\max\v0\Compiling">
+      <UniqueIdentifier>{c79a2bc5-4845-4128-8999-f4ae5cf4ca9e}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -101,45 +101,6 @@
     </None>
     <None Include="..\..\..\Code\Include\max\Containers\Range.inl">
       <Filter>Code\Include\max\Containers</Filter>
-    </None>
-    <None Include="..\..\..\Documentation\max\v0\Algorithms\IsBetween.md">
-      <Filter>Documentation\max\v0\Algorithms</Filter>
-    </None>
-    <None Include="..\..\..\Documentation\max\v0\Compiling\AliasingOptimizations.md">
-      <Filter>Documentation\max\v0\Compiling</Filter>
-    </None>
-    <None Include="..\..\..\Documentation\max\v0\Compiling\MAX_PURE.md">
-      <Filter>Documentation\max\v0\Compiling</Filter>
-    </None>
-    <None Include="..\..\..\Documentation\max\v0\Compiling\MAX_PURE_WITH_GLOBALS.md">
-      <Filter>Documentation\max\v0\Compiling</Filter>
-    </None>
-    <None Include="..\..\..\Documentation\max\v0\Compiling\MAX_RESTRICTED_POINTER.md">
-      <Filter>Documentation\max\v0\Compiling</Filter>
-    </None>
-    <None Include="..\..\..\Documentation\max\v0\Compiling\MAX_RESTRICTED_REFERENCE.md">
-      <Filter>Documentation\max\v0\Compiling</Filter>
-    </None>
-    <None Include="..\..\..\Documentation\max\v0\Compiling\MAX_RETURNS_RESTRICTED_POINTER.md">
-      <Filter>Documentation\max\v0\Compiling</Filter>
-    </None>
-    <None Include="..\..\..\Documentation\max\v0\Compiling\MAX_SEMI_PURE.md">
-      <Filter>Documentation\max\v0\Compiling</Filter>
-    </None>
-    <None Include="..\..\..\Documentation\max\v0\Containers\MakeRange.md">
-      <Filter>Documentation\max\v0\Containers</Filter>
-    </None>
-    <None Include="..\..\..\Documentation\max\v0\Containers\Range.md">
-      <Filter>Documentation\max\v0\Containers</Filter>
-    </None>
-    <None Include="..\..\..\Documentation\max\v0\Containers\Range_ctor.md">
-      <Filter>Documentation\max\v0\Containers</Filter>
-    </None>
-    <None Include="..\..\..\Documentation\max\v0.md">
-      <Filter>Documentation\max</Filter>
-    </None>
-    <None Include="..\..\..\Documentation\StyleGuide.md">
-      <Filter>Documentation</Filter>
     </None>
     <None Include="..\..\..\LICENSE" />
     <None Include="..\..\..\Code\Include\max\Algorithms\Math.inl">
@@ -168,6 +129,60 @@
     </None>
     <None Include="..\..\..\Code\Include\max\Testing\TestSuite.inl">
       <Filter>Code\Include\max\Testing</Filter>
+    </None>
+    <None Include="..\..\..\Docs\code_of_conduct.md">
+      <Filter>Docs</Filter>
+    </None>
+    <None Include="..\..\..\Docs\DeprecationSchedule.md">
+      <Filter>Docs</Filter>
+    </None>
+    <None Include="..\..\..\Docs\README.md">
+      <Filter>Docs</Filter>
+    </None>
+    <None Include="..\..\..\Docs\StyleGuide.md">
+      <Filter>Docs</Filter>
+    </None>
+    <None Include="..\..\..\Docs\max\v0.md">
+      <Filter>Docs\max\v0</Filter>
+    </None>
+    <None Include="..\..\..\Docs\max\v0\Compiling\AliasingOptimizations.md">
+      <Filter>Docs\max\v0\Compiling</Filter>
+    </None>
+    <None Include="..\..\..\Docs\max\v0\Compiling\MAX_PURE.md">
+      <Filter>Docs\max\v0\Compiling</Filter>
+    </None>
+    <None Include="..\..\..\Docs\max\v0\Compiling\MAX_PURE_WITH_GLOBALS.md">
+      <Filter>Docs\max\v0\Compiling</Filter>
+    </None>
+    <None Include="..\..\..\Docs\max\v0\Compiling\MAX_RESTRICTED_POINTER.md">
+      <Filter>Docs\max\v0\Compiling</Filter>
+    </None>
+    <None Include="..\..\..\Docs\max\v0\Compiling\MAX_RESTRICTED_REFERENCE.md">
+      <Filter>Docs\max\v0\Compiling</Filter>
+    </None>
+    <None Include="..\..\..\Docs\max\v0\Compiling\MAX_RETURNS_RESTRICTED_POINTER.md">
+      <Filter>Docs\max\v0\Compiling</Filter>
+    </None>
+    <None Include="..\..\..\Docs\max\v0\Compiling\MAX_SEMI_PURE.md">
+      <Filter>Docs\max\v0\Compiling</Filter>
+    </None>
+    <None Include="..\..\..\Docs\max\v0\Algorithms\IsBetween.md">
+      <Filter>Docs\max\v0\Algorithms</Filter>
+    </None>
+    <None Include="..\..\..\Docs\max\v0\Containers\MakeRange.md">
+      <Filter>Docs\max\v0\Containers</Filter>
+    </None>
+    <None Include="..\..\..\Docs\max\v0\Containers\Range.md">
+      <Filter>Docs\max\v0\Containers</Filter>
+    </None>
+    <None Include="..\..\..\Docs\max\v0\Containers\Range_ctor.md">
+      <Filter>Docs\max\v0\Containers</Filter>
+    </None>
+    <None Include="..\..\..\Docs\max\v0\Compiling\Macros.md">
+      <Filter>Docs\max\v0\Compiling</Filter>
+    </None>
+    <None Include="..\..\..\Docs\max\v0\Compiling\MAX_COMPILER_MESSAGE.md">
+      <Filter>Docs\max\v0\Compiling</Filter>
     </None>
   </ItemGroup>
   <ItemGroup>
@@ -341,6 +356,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\Code\Include\max\Testing\CoutResultPolicy.hpp">
       <Filter>Code\Include\max\Testing</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Code\Include\max\Compiling\Macros.hpp">
+      <Filter>Code\Include\max\Compiling</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Projects/VisualStudio/maxManualTests/maxManualTests.vcxproj
+++ b/Projects/VisualStudio/maxManualTests/maxManualTests.vcxproj
@@ -20,10 +20,12 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Code\ManualTests\AliasingOptimizationsTest.cpp" />
+    <ClCompile Include="..\..\..\Code\ManualTests\ConfigurationTest.cpp" />
     <ClCompile Include="..\..\..\Code\ManualTests\EntryPoint.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Code\ManualTests\AliasingOptimizationsTest.hpp" />
+    <ClInclude Include="..\..\..\Code\ManualTests\ConfigurationTest.hpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{76F87B4A-ACB7-47BD-91B1-7071DFA4D870}</ProjectGuid>

--- a/Projects/VisualStudio/maxManualTests/maxManualTests.vcxproj.filters
+++ b/Projects/VisualStudio/maxManualTests/maxManualTests.vcxproj.filters
@@ -10,9 +10,15 @@
     <ClCompile Include="..\..\..\Code\ManualTests\AliasingOptimizationsTest.cpp">
       <Filter>Compiling</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Code\ManualTests\ConfigurationTest.cpp">
+      <Filter>Compiling</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Code\ManualTests\AliasingOptimizationsTest.hpp">
+      <Filter>Compiling</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Code\ManualTests\ConfigurationTest.hpp">
       <Filter>Compiling</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This commit adds a macro to print a compile-time message. It also adds macros to stringify parameters.