### PR TITLE
Fix Cppcheck

### DIFF
--- a/Tooling/Cppcheck/.gitignore
+++ b/Tooling/Cppcheck/.gitignore
@@ -1,0 +1,1 @@
+max-cppcheck-build-dir/

--- a/Tooling/Cppcheck/max.cppcheck
+++ b/Tooling/Cppcheck/max.cppcheck
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="1">
-    <includedir>
-        <dir name="Code/Include/"/>
-    </includedir>
+    <builddir>max-cppcheck-build-dir</builddir>
+    <platform>Unspecified</platform>
+    <importproject>../../Projects/VisualStudio/max.sln</importproject>
+    <analyze-all-vs-configs>true</analyze-all-vs-configs>
 </project>


### PR DESCRIPTION
Cppcheck's file wasn't updated when code moved.
Additionally, there is a new set of things which can be stored
inside. So that file was updated.

A .gitignore was added for this directory to prevent saving the
build directory.