### PR TITLE
Fix ARM compiling

### DIFF
--- a/Code/max/Compiling/Configuration/Platform/Linux.hpp
+++ b/Code/max/Compiling/Configuration/Platform/Linux.hpp
@@ -13,17 +13,29 @@
 	#if defined( __x86_64__ )
 		#define MAX_64BIT_WORD_SIZE
 		#define MAX_X86_64
-		#define MAX_LITTLE_ENDIAN
 	#elif defined( __i386__ )
 		#define MAX_32BIT_WORD_SIZE
 		#define MAX_X86
-		#define MAX_LITTLE_ENDIAN
 	#elif defined( __IA64__ )
 		#define MAX_64BIT_WORD_SIZE
 		#define MAX_IA64
-		#define MAX_LITTLE_ENDIAN
+	#elif defined( __aarch64__ )
+		#define MAX_64BIT_WORD_SIZE
+		#define MAX_AARCH64
+	#elif defined( __arm__ )
+		#define MAX_32BIT_WORD_SIZE
+		#define MAX_ARM
+	#elif defined( __thumb__ )
+		#define MAX_16BIT_WORD_SIZE
+		#define MAX_THUMB
 	#else
 		static_assert( false, "Unknown platform" );
+	#endif
+
+	#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+		#define MAX_LITTLE_ENDIAN
+	#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+		#define MAX_BIG_ENDIAN
 	#endif
 #else
 	static_assert( false, "Unknown platform" );

--- a/Code/max/Compiling/Configuration/Platform/Win32.hpp
+++ b/Code/max/Compiling/Configuration/Platform/Win32.hpp
@@ -38,6 +38,13 @@
 		#define MAX_64BIT_WORD_SIZE
 		#define MAX_IA64
 		#define MAX_LITTLE_ENDIAN
+	#elif defined( _M_ARM )
+		#define MAX_32BIT_WORD_SIZE
+		#define MAX_ARM
+	#elif defined( _M_ARMT )
+		// Thumb mode
+		#define MAX_16BIT_WORD_SIZE
+		#define MAX_THUMB
 	#else
 		static_assert( false, "Unknown platform" );
 	#endif

--- a/Code/max/Hardware/CPU/CPUID.cpp
+++ b/Code/max/Hardware/CPU/CPUID.cpp
@@ -29,9 +29,12 @@
 	#if defined( MAX_X86_64 )
 		#include <max/Hardware/CPU/IsCPUIDAvailablePolicies/X64GCCAssemblyIsCPUIDAvailablePolicy.hpp>
 		#include <max/Hardware/CPU/CPUIDPolicies/X64GCCAssemblyCPUIDPolicy.hpp>
-	#elif defined (MAX_X86 )
+	#elif defined( MAX_X86 )
 		#include <max/Hardware/CPU/IsCPUIDAvailablePolicies/X86GCCAssemblyIsCPUIDAvailablePolicy.hpp>
 		#include <max/Hardware/CPU/CPUIDPolicies/X86GCCAssemblyCPUIDPolicy.hpp>
+	#elif defined( MAX_AARCH64 ) || defined( MAX_ARM ) || defined( MAX_THUMB )
+		#include <max/Hardware/CPU/IsCPUIDAvailablePolicies/ArmIsCPUIDAvailablePolicy.hpp>
+		#include <max/Hardware/CPU/CPUIDPolicies/AArch64CPUIDPolicy.hpp>
 	#else
 		static_assert( false, "Unsupported platform" );
 	#endif
@@ -1285,6 +1288,9 @@ namespace CPU
 	#elif defined( MAX_X86 )
 		typedef X86GCCAssemblyIsCPUIDAvailablePolicy   IsCPUIDAvailablePolicy;
 		typedef X86GCCAssemblyCPUIDPolicy              CPUIDPolicy;
+	#elif defined( MAX_AARCH64 ) || defined( MAX_ARM ) || defined( MAX_THUMB )
+		typedef ArmIsCPUIDAvailablePolicy              IsCPUIDAvailablePolicy;
+		typedef AArch64CPUIDPolicy                     CPUIDPolicy;
 	#else
 		static_assert( false, "Unsupported platform" );
 	#endif

--- a/Code/max/Hardware/CPU/CPUIDPolicies/AArch64CPUIDPolicy.cpp
+++ b/Code/max/Hardware/CPU/CPUIDPolicies/AArch64CPUIDPolicy.cpp
@@ -1,0 +1,21 @@
+// Copyright 2019, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <max/Hardware/CPU/CPUIDPolicies/AArch64CPUIDPolicy.hpp>
+
+namespace max
+{
+namespace CPU
+{
+
+	void AArch64CPUIDPolicy::CPUID( CPUIDSubleafResult & /*Registers*/, uint32_t /*Leaf*/ ) noexcept
+	{
+	}
+
+	void AArch64CPUIDPolicy::CPUIDExtended( CPUIDSubleafResult & /*Registers*/, uint32_t /*Leaf*/, uint32_t /*Subleaf*/ ) noexcept
+	{
+	}
+
+} // namespace CPU
+} // namespace max

--- a/Code/max/Hardware/CPU/CPUIDPolicies/AArch64CPUIDPolicy.hpp
+++ b/Code/max/Hardware/CPU/CPUIDPolicies/AArch64CPUIDPolicy.hpp
@@ -1,0 +1,29 @@
+// Copyright 2019, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_CPU_AARCH64CPUIDPOLICY_HPP
+#define MAX_CPU_AARCH64CPUIDPOLICY_HPP
+
+#include <array>
+#include <cstdint>
+#include "../CPUIDSubleafResult.hpp"
+
+namespace max
+{
+namespace CPU
+{
+
+	class AArch64CPUIDPolicy
+	{
+	public:
+
+		static void CPUID(         CPUIDSubleafResult & Registers, uint32_t Leaf )                   noexcept;
+		static void CPUIDExtended( CPUIDSubleafResult & Registers, uint32_t Leaf, uint32_t Subleaf ) noexcept;
+
+	};
+
+} // namespace CPU
+} // namespace max
+
+#endif // #ifndef MAX_CPU_AARCH64CPUIDPOLICY_HPP

--- a/Code/max/Hardware/CPU/IsCPUIDAvailablePolicies/ArmIsCPUIDAvailablePolicy.hpp
+++ b/Code/max/Hardware/CPU/IsCPUIDAvailablePolicies/ArmIsCPUIDAvailablePolicy.hpp
@@ -1,0 +1,24 @@
+// Copyright 2019, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_CPUID_ARMISCPUIDAVAILABLEPOLICY_HPP
+#define MAX_CPUID_ARMISCPUIDAVAILABLEPOLICY_HPP
+
+namespace max
+{
+namespace CPU
+{
+
+	class ArmIsCPUIDAvailablePolicy
+	{
+	public:
+
+		static bool IsCPUIDAvailable() noexcept { return true; }
+
+	};
+
+} // namespace CPU
+} // namespace max
+
+#endif // #ifndef MAX_CPUID_ARMISCPUIDAVAILABLEPOLICY_HPP

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -25,7 +25,7 @@ It includes common code such as logging, testing, abstractions for compiler and 
     * iOS*
 * Instruction sets:
     * x86 (64)
-    * ARM*
+    * ARM
 
 *Coming soon
 

--- a/Projects/Clang AArch64 Make/Makefile
+++ b/Projects/Clang AArch64 Make/Makefile
@@ -1,0 +1,67 @@
+PROGRAM_NAME = max
+CXX_SRCS = \
+	../../Code/max/Hardware/CPU/CPUIDPolicies/AArch64CPUIDPolicy.cpp \
+	../../Code/max/Hardware/CPU/Associativity.cpp \
+	../../Code/max/Hardware/CPU/CacheInfo.cpp \
+	../../Code/max/Hardware/CPU/CacheLevel.cpp \
+	../../Code/max/Hardware/CPU/CPUID.cpp \
+	../../Code/max/Hardware/CPU/CPUIDSubleafArgumentsAndResult.cpp \
+	../../Code/max/Hardware/CPU/Prefetch.cpp \
+	../../Code/max/Hardware/CPU/TLB.cpp \
+	../../Code/max/Hardware/CPU/TraceCache.cpp \
+	../../Code/max/Logging/DoNothingLogger.cpp \
+	../../Code/max/Testing/CoutResultPolicy.cpp
+CXX_OBJS = $(CXX_SRCS:.cpp=.o)
+
+INCLUDE_PATHS = \
+	../../Code
+INCLUDE_PATHS_FLAGS = $(foreach d, $(INCLUDE_PATHS), -I$d)
+
+LIBRARY_PATHS = \
+	.
+LIBRARY_PATHS_FLAGS = $(foreach d, $(LIBRARY_PATHS), -L$d)
+
+AUTOMATED_TEST_CXX_SRCS = \
+	../../Code/max/Algorithms/IsBetweenTest.cpp \
+	../../Code/max/Containers/Bits8Test.cpp \
+	../../Code/max/Containers/Bits16Test.cpp \
+	../../Code/max/Containers/Bits32Test.cpp \
+	../../Code/max/Containers/RangeTest.cpp \
+	../../Code/max/Containers/VectorTest.cpp \
+	../../Code/max/Testing/AutomatedTestsEntryPoint.cpp
+AUTOMATED_TEST_CXX_OBJS = $(AUTOMATED_TEST_CXX_SRCS:.cpp=.o)
+
+MANUAL_TEST_CXX_SRCS = \
+	../../Code/max/Compiling/AliasingOptimizationsTest.cpp \
+	../../Code/max/Compiling/ConfigurationTest.cpp \
+	../../Code/max/Testing/ManualTestsEntryPoint.cpp
+MANUAL_TEST_CXX_OBJS = $(MANUAL_TEST_CXX_SRCS:.cpp=.o)
+
+CPPFLAGS += $(INCLUDE_PATHS_FLAGS) -std=c++14 -Werror -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion
+LINKER_FLAGS += $(LIBRARY_PATHS_FLAGS)
+
+
+
+
+all: lib$(PROGRAM_NAME).a maxAutomatedTests maxManualTests
+
+lib$(PROGRAM_NAME).a: $(PCH_OBJS) $(CXX_OBJS)
+	ar rcs lib$(PROGRAM_NAME).a $(CXX_OBJS)
+
+maxAutomatedTests: $(AUTOMATED_TEST_CXX_OBJS)
+	clang++ -g $(AUTOMATED_TEST_CXX_OBJS) $(LINKER_FLAGS) -l$(PROGRAM_NAME) -o maxAutomatedTests
+
+maxManualTests: $(MANUAL_TEST_CXX_OBJS)
+	clang++ -g $(MANUAL_TEST_CXX_OBJS) $(LINKER_FLAGS) -l$(PROGRAM_NAME) -o maxManualTests
+.cpp.o:
+	clang++ -g $(CPPFLAGS) -c $< -o $@
+
+clean:
+	@- $(RM) lib$(PROGRAM_NAME).a
+	@- $(RM) $(CXX_OBJS)
+	@- $(RM) maxAutomatedTests
+	@- $(RM) $(AUTOMATED_TEST_CXX_OBJS)
+	@- $(RM) maxManualTests
+	@- $(RM) $(MANUAL_TEST_CXX_OBJS)
+
+distclean: clean


### PR DESCRIPTION
This commit fixes the ARM compiles.

There is still work to be done to get parity to x86:
- The Vector unit tests fail because of the call to sqrt().
- The CPUID code needs to be reworked.

But this is progress in the right direction. :)

Partially fixes #26 