### PR TITLE
Fix Cout assertions

### DIFF
--- a/Code/max/Testing/CoutResultPolicy.cpp
+++ b/Code/max/Testing/CoutResultPolicy.cpp
@@ -44,9 +44,9 @@ namespace Testing
 	                                 int LineNumber,
 	                                 char const * const ExpressionString )
 	{
-		std::cout << L"Assert failed: " << ExpressionString << "\n";
-		std::cout << L"\tin file " << FileName << "\n";
-		std::cout << L"\ton line " << LineNumber << std::endl;
+		std::cout << "Assert failed: " << ExpressionString << "\n";
+		std::cout << "\tin file " << FileName << "\n";
+		std::cout << "\ton line " << LineNumber << std::endl;
 	}
 
 	void CoutResultPolicy::OnTestSuiteTearDown( std::string const & TestSuiteName )


### PR DESCRIPTION
When using the Cout assertion policy, any assertion would attempt
to use a wide string when printing to cout (as opposed to wcout).

This would produce faulty output.

This commit fixes it to use normal strings which match cout.