### PR TITLE
Update AppVeyor badge

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -49,5 +49,5 @@ You can reference the full [deprecation schedule](DeprecationSchedule.md) for ex
 
 [travis-shield]: https://travis-ci.org/ProgramMax/max.svg?branch=master
 [travis-link]: https://travis-ci.org/ProgramMax/max/builds
-[appveyor-shield]: https://ci.appveyor.com/api/projects/status/7wjmpyqh6gnc70g5?svg=true
-[appveyor-link]: https://ci.appveyor.com/project/ProgramMax/max
+[appveyor-shield]: https://ci.appveyor.com/api/projects/status/7wjmpyqh6gnc70g5/branch/master?svg=true
+[appveyor-link]: https://ci.appveyor.com/project/ProgramMax/max/branch/master


### PR DESCRIPTION
The AppVeyor badge was showing the last build's result, rather
than the last build of master. This is incorrect because a pull
request could fail and make it look like the project as a whole is
failing.

This commit fixes the AppVeyor badge to only reflect master.