### PR TITLE
Update compiler version and deprecation schedule

### DIFF
--- a/Code/max/Compiling/Configuration/Compiler/VC.hpp
+++ b/Code/max/Compiling/Configuration/Compiler/VC.hpp
@@ -9,9 +9,13 @@
 
 #define MAX_COMPILER_MESSAGE(Message) __pragma(message(Message))
 
-#if _MSC_VER > 1923
+#if _MSC_VER > 1924
 MAX_COMPILER_MESSAGE("Compiling with a newer version of MSVC than max recognizes.");
-#elif _MSC_VER == 1923
+#elif _MSC_VER == 1924
+	// MSVC++ 14.24 (Visual Studio 2019 / version 16.4)
+	#define MAX_COMPILER_VERSION_MAJOR 16
+	#define MAX_COMPILER_VERSION_MINOR 4
+#elif _MSC_VER >= 1923
 	// MSVC++ 14.23 (Visual Studio 2019 / version 16.3)
 	#define MAX_COMPILER_VERSION_MAJOR 16
 	#define MAX_COMPILER_VERSION_MINOR 3

--- a/Docs/DeprecationSchedule.md
+++ b/Docs/DeprecationSchedule.md
@@ -2,7 +2,8 @@
 
 |Clang version|Release date|max deprecation date|
 |-------------|-----------:|-------------------:|
-|Clang 8.0.x  |Mar 20, 2019|             Current|
+|Clang 9.0.x  |Sep 19, 2019|             Current|
+|Clang 8.0.x  |Mar 20, 2019|        Sep 19, 2024|
 |Clang 7.0.x  |Sep 19, 2018|        Mar 20, 2024|
 |Clang 6.0.x  |Mar  8, 2018|        Sep 19, 2023|
 |Clang 5.0.x  |Sep  7, 2018|        Mar  8, 2023|
@@ -12,8 +13,7 @@
 |Clang 3.7.x  |Sep  1, 2015|        Mar  8, 2021|
 |Clang 3.6.x  |Feb 27, 2015|        Sep  1, 2020|
 |Clang 3.5.x  |Sep  3, 2014|        Feb 27, 2020|
-|Clang 3.4.x  |Jan  2, 2014|        Sep  3, 2019|
-|Clang 3.3    |Jun 17, 2013|          Deprecated|
+|Clang 3.4.x  |Jan  2, 2014|          Deprecated|
 
 |GCC version|Release date|max deprecation date|
 |-----------|-----------:|-------------------:|
@@ -35,7 +35,9 @@
 
 |MSVC version      |Release date|max deprecation date|
 |------------------|-----------:|-------------------:|
-|MSVC 16.2.x       |Jul 24, 2019|             Current|
+|MSVC 16.4.x       |Dec  3, 2019|             Current|
+|MSVC 16.3.x       |Sep 23, 2019|        Dec  3, 2024|
+|MSVC 16.2.x       |Jul 24, 2019|        Sep 23, 2024|
 |MSVC 16.1.x       |May 21, 2019|        Jul 24, 2024|
 |MSVC 16.0.x       |Apr  2, 2019|        May 21, 2024|
 |MSVC 15.9.x       |Nov 13, 2018|        Apr  2, 2024|
@@ -53,8 +55,7 @@
 |MSVC 2015 Update 1|Nov 30, 2015|        Mar 30, 2021|
 |MSVC 2015         |Jul 20, 2015|        Nov 30, 2020|
 |MSVC 2013 Update 4|Nov 12, 2014|        Jul 20, 2020|
-|MSVC 2013 Update 3|Aug  4, 2014|        Nov 12, 2019|
-|MSVC 2013 Update 2|Apr  2, 2014|          Deprecated|
+|MSVC 2013 Update 3|Aug  4, 2014|          Deprecated|
 
 |Windows version|Release date|max deprecation date|
 |---------------|-----------:|-------------------:|


### PR DESCRIPTION
There are updates to Clang and MSVC. Plus, since time has passed,
the deprecation schedule can entries that can be marked deprecated.

This commit updates the deprecation schedule and the last-known
MSVC version.