### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ProgramMax


### PR DESCRIPTION
The commit adds a CODEOWNERS file in .github/ to assign
@ProgramMax as a default fall-back reviewer.