### PR TITLE
Update MSVC version & deprecation schedule

### DIFF
--- a/Code/max/Compiling/Configuration/Compiler/VC.hpp
+++ b/Code/max/Compiling/Configuration/Compiler/VC.hpp
@@ -9,9 +9,13 @@
 
 #define MAX_COMPILER_MESSAGE(Message) __pragma(message(Message))
 
-#if _MSC_VER > 1924
-MAX_COMPILER_MESSAGE("Compiling with a newer version of MSVC than max recognizes.");
-#elif _MSC_VER == 1924
+#if _MSC_VER > 1925
+	MAX_COMPILER_MESSAGE("Compiling with a newer version of MSVC than max recognizes. Using last known version.");
+#elif _MSC_VER >= 1925
+	// MSVC++ 14.25 (Visual Studio 2019 / version 16.5)
+	#define MAX_COMPILER_VERSION_MAJOR 16
+	#define MAX_COMPILER_VERSION_MINOR 5
+#elif _MSC_VER >= 1924
 	// MSVC++ 14.24 (Visual Studio 2019 / version 16.4)
 	#define MAX_COMPILER_VERSION_MAJOR 16
 	#define MAX_COMPILER_VERSION_MINOR 4

--- a/Docs/DeprecationSchedule.md
+++ b/Docs/DeprecationSchedule.md
@@ -29,12 +29,12 @@
 |GCC 5.3    |Dec  4, 2015|        Apr 27, 2021|
 |GCC 5.2    |Jul 16, 2015|        Dec  4, 2020|
 |GCC 5.1    |Apr 22, 2015|        Jul 16, 2020|
-|GCC 4.9.x  |Apr 22, 2014|        Apr 22, 2020|
-|GCC 4.8.x  |Mar 22, 2013|          Deprecated|
+|GCC 4.9.x  |Apr 22, 2014|          Deprecated|
 
 |MSVC version      |Release date|max deprecation date|
 |------------------|-----------:|-------------------:|
-|MSVC 16.4.x       |Dec  3, 2019|             Current|
+|MSVC 16.5.x       |Mar 16, 2020|             Current|
+|MSVC 16.4.x       |Dec  3, 2019|        Mar 16, 2025|
 |MSVC 16.3.x       |Sep 23, 2019|        Dec  3, 2024|
 |MSVC 16.2.x       |Jul 24, 2019|        Sep 23, 2024|
 |MSVC 16.1.x       |May 21, 2019|        Jul 24, 2024|


### PR DESCRIPTION
A new version of MSVC has been released. In addition, an old GCC
has become deprecated. This commit reflects those changes.