### PR TITLE
Remove excess space

### DIFF
--- a/Code/max/Hardware/CPU/CPUIDPolicies/X64GCCAssemblyCPUIDPolicy.cpp
+++ b/Code/max/Hardware/CPU/CPUIDPolicies/X64GCCAssemblyCPUIDPolicy.cpp
@@ -34,7 +34,7 @@ namespace CPU
 			  "=d"( Registers.EDX )
 			: "a"( Leaf ),
 			  "c"( Subleaf )
-			:  );
+			: );
 	}
 
 } // namespace CPU


### PR DESCRIPTION
There are two spaces where only one is appropriate. This commit removes
the excess space.