### PR TITLE
Update Visual Studio projects

### DIFF
--- a/Projects/VisualStudio/max/max.vcxproj
+++ b/Projects/VisualStudio/max/max.vcxproj
@@ -118,8 +118,6 @@
     <ClInclude Include="..\..\..\Code\max\Compiling\MemoryBarrier.hpp" />
     <ClInclude Include="..\..\..\Code\max\Compiling\NoDefault.hpp" />
     <ClInclude Include="..\..\..\Code\max\Compiling\Polyfills\IsConstantEvaluated.hpp" />
-    <ClInclude Include="..\..\..\Code\max\Compiling\StaticAssert.hpp" />
-    <ClInclude Include="..\..\..\Code\max\Compiling\ThrowSpecification.hpp" />
     <ClInclude Include="..\..\..\Code\max\Compiling\UnreferencedValue.hpp" />
     <ClInclude Include="..\..\..\Code\max\Compiling\VirtualFunctionSpecification.hpp" />
     <ClInclude Include="..\..\..\Code\max\Containers\Range.hpp" />

--- a/Projects/VisualStudio/max/max.vcxproj.filters
+++ b/Projects/VisualStudio/max/max.vcxproj.filters
@@ -275,12 +275,6 @@
     <ClInclude Include="..\..\..\Code\max\Compiling\NoDefault.hpp">
       <Filter>Code\max\Compiling</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\Code\max\Compiling\StaticAssert.hpp">
-      <Filter>Code\max\Compiling</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\Code\max\Compiling\ThrowSpecification.hpp">
-      <Filter>Code\max\Compiling</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\Code\max\Compiling\UnreferencedValue.hpp">
       <Filter>Code\max\Compiling</Filter>
     </ClInclude>


### PR DESCRIPTION
Previously, the throw specification and static assert polyfills were
removed. However, the Visual Studio projects were not updated to remove
the files. This commit removes those files from the Visual Studio
projects.