### PR TITLE
Update VC and deprecation schedule

### DIFF
--- a/Code/max/Algorithms/CountZeroes.inl
+++ b/Code/max/Algorithms/CountZeroes.inl
@@ -427,7 +427,7 @@ namespace max
 					#elif defined( MAX_COMPILER_VC ) && defined( MAX_X86_64 )
 						unsigned long Position = 0;
 						_BitScanReverse64( &Position, Value );
-						return Position;
+						return 63 - Position;
 					#else
 						return ImplementationDetails::CheckLeadingBit63( Value );
 					#endif
@@ -499,7 +499,7 @@ namespace max
 					#elif defined( MAX_COMPILER_VC ) && defined( MAX_X86_64 )
 						unsigned long Position = 0;
 						_BitScanReverse64( &Position, static_cast< uint64_t >( Value ) );
-						return Position;
+						return 63 - Position;
 					#else
 						return ImplementationDetails::CheckLeadingBit63( static_cast< const uint64_t >( Value ) );
 					#endif

--- a/Code/max/Compiling/Configuration/Compiler/VC.hpp
+++ b/Code/max/Compiling/Configuration/Compiler/VC.hpp
@@ -5,17 +5,22 @@
 #ifndef MAX_COMPILING_CONFIGURATION_COMPILER_VC_HPP
 #define MAX_COMPILING_CONFIGURATION_COMPILER_VC_HPP
 
-
-#include <version>
-
 #include <max/Compiling/Macros.hpp>
 
 #define MAX_COMPILER_VC
 
 #define MAX_COMPILER_MESSAGE( Message ) __pragma( message( Message ) )
 
-#if _MSC_VER > 1926
+#if _MSC_VER > 1928
 	MAX_COMPILER_MESSAGE( "Compiling with a newer version of MSVC than max recognizes. Using last known version." );
+#elif _MSC_VER >= 1928
+	// MSVC++ 14.28 (Visual Studio 2019 / version 16.8)
+	#define MAX_COMPILER_VERSION_MAJOR 16
+	#define MAX_COMPILER_VERSION_MINOR 8
+#elif _MSC_VER >= 1927
+	// MSVC++ 14.27 (Visual Studio 2019 / versoin 16.7)
+	#define MAX_COMPILER_VERSION_MAJOR 16
+	#define MAX_COMPILER_VERSION_MINOR 7
 #elif _MSC_VER >= 1926
 	// MSVC++ 14.26 (Visual Studio 2019 / version 16.6)
 	#define MAX_COMPILER_VERSION_MAJOR 16
@@ -226,8 +231,15 @@
 	#define MAX_CONSTEXPR_SUPPORTED
 #endif
 
-#if ( MAX_COMPILER_VERSION_AT_LEAST( 16, 5, 0 ) && defined ( _MSVC_LANG ) && _MSVC_LANG >= 201704L ) || __cpp_lib_is_constant_evaluated
-	#define MAX_IS_CONSTANT_EVALUATED_SUPPORTED
+#if MAX_COMPILER_VERSION_AT_LEAST( 15, 3, 0 )
+	#define MAX_HAS_INCLUDE_SUPPORTED
+#endif
+
+#if MAX_COMPILER_VERSION_AT_LEAST( 16, 2, 0 )
+	#include <version>
+	#if ( MAX_COMPILER_VERSION_AT_LEAST( 16, 5, 0 ) && defined ( _MSVC_LANG ) && _MSVC_LANG >= 201704L ) || __cpp_lib_is_constant_evaluated
+		#define MAX_IS_CONSTANT_EVALUATED_SUPPORTED
+	#endif
 #endif
 
 #endif // #ifndef MAX_COMPILING_CONFIGURATION_COMPILER_VC_HPP

--- a/Code/max/Hardware/CPU/CPUID.cpp
+++ b/Code/max/Hardware/CPU/CPUID.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <utility>
 #include <array>
+#include <iterator>
 #include <memory>
 #include <cstring>
 #include <max/Hardware/CPU/TLB.hpp>

--- a/Docs/DeprecationSchedule.md
+++ b/Docs/DeprecationSchedule.md
@@ -2,7 +2,8 @@
 
 |Clang version|Release date|max deprecation date|Adds support for      |
 |-------------|-----------:|-------------------:|----------------------|
-|Clang 10.0.x |Mar 24, 2020|             Current|concepts, constinit   |
+|Clang 11.0.x |Oct 12, 2020|             Current|                      |
+|Clang 10.0.x |Mar 24, 2020|        Oct 12, 2025|concepts, constinit   |
 |Clang 9.0.x  |Sep 19, 2019|        Mar 24, 2025|bit operations        |
 |Clang 8.0.x  |Mar 20, 2019|        Sep 19, 2024|                      |
 |Clang 7.0.x  |Sep 19, 2018|        Mar 20, 2024|std::endian, <version>|
@@ -12,8 +13,7 @@
 |Clang 3.9.x  |Sep  2, 2016|        Mar 13, 2022|                      |
 |Clang 3.8.x  |Mar  8, 2016|        Sep  2, 2021|                      |
 |Clang 3.7.x  |Sep  1, 2015|        Mar  8, 2021|                      |
-|Clang 3.6.x  |Feb 27, 2015|        Sep  1, 2020|                      |
-|Clang 3.5.x  |Sep  3, 2014|          Deprecated|                      |
+|Clang 3.6.x  |Feb 27, 2015|          Deprecated|                      |
 
 |GCC version|Release date|max deprecation date|Adds support for                                |
 |-----------|-----------:|-------------------:|------------------------------------------------|
@@ -34,33 +34,33 @@
 |GCC 5.2    |Jul 16, 2015|        Dec  4, 2020|                                                |
 |GCC 5.1    |Apr 22, 2015|          Deprecated|                                                |
 
-|MSVC version      |Release date|max deprecation date|Adds support for      |
-|------------------|-----------:|-------------------:|----------------------|
-|MSVC 16.6.x       |May 19, 2020|             Current|                      |
-|MSVC 16.5.x       |Mar 16, 2020|        May 19, 2025|bit operations        |
-|MSVC 16.4.x       |Dec  3, 2019|        Mar 16, 2025|                      |
-|MSVC 16.3.x       |Sep 23, 2019|        Dec  3, 2024|concepts              |
-|MSVC 16.2.x       |Jul 24, 2019|        Sep 23, 2024|std::endian, <version>|
-|MSVC 16.1.x       |May 21, 2019|        Jul 24, 2024|std::shift_*          |
-|MSVC 16.0.x       |Apr  2, 2019|        May 21, 2024|                      |
-|MSVC 15.9.x       |Nov 13, 2018|        Apr  2, 2024|                      |
-|MSVC 15.8.x       |Aug 14, 2018|        Nov 13, 2023|                      |
-|MSVC 15.7.x       |May  7, 2018|        Aug 14, 2023|                      |
-|MSVC 15.6.x       |Mar  5, 2018|        May  7, 2023|                      |
-|MSVC 15.5.x       |Dec  4, 2017|        Mar  5, 2023|                      |
-|MSVC 15.4.x       |Oct  9, 2017|        Dec  4, 2022|                      |
-|MSVC 15.3.x       |Aug 14, 2017|        Oct  9, 2022|                      |
-|MSVC 15.2.x       |May 10, 2017|        Aug 14, 2022|                      |
-|MSVC 15.1.x       |Apr  5, 2017|        May 10, 2022|                      |
-|MSVC 15.0.x       |Mar  7, 2017|        Apr  5, 2022|std::optional         |
-|MSVC 2015 Update 3|Jun 27, 2016|        Mar  7, 2022|                      |
-|MSVC 2015 Update 2|Mar 30, 2016|        Jun 27, 2021|                      |
-|MSVC 2015 Update 1|Nov 30, 2015|        Mar 30, 2021|                      |
-|MSVC 2015         |Jul 20, 2015|        Nov 30, 2020|                      |
-|MSVC 2013 Update 4|Nov 12, 2014|          Deprecated|                      |
+|MSVC version      |Release date|max deprecation date|Adds support for           |
+|------------------|-----------:|-------------------:|---------------------------|
+|MSVC 16.8.x       |Nov 10, 2020|             Current|modules, coroutines, ranges|
+|MSVC 16.7.x       |Aug  5, 2020|        Nov 10, 2025|                           |
+|MSVC 16.6.x       |May 19, 2020|        Aug  5, 2025|                           |
+|MSVC 16.5.x       |Mar 16, 2020|        May 19, 2025|bit operations             |
+|MSVC 16.4.x       |Dec  3, 2019|        Mar 16, 2025|                           |
+|MSVC 16.3.x       |Sep 23, 2019|        Dec  3, 2024|concepts                   |
+|MSVC 16.2.x       |Jul 24, 2019|        Sep 23, 2024|std::endian, <version>     |
+|MSVC 16.1.x       |May 21, 2019|        Jul 24, 2024|std::shift_*               |
+|MSVC 16.0.x       |Apr  2, 2019|        May 21, 2024|                           |
+|MSVC 15.9.x       |Nov 13, 2018|        Apr  2, 2024|                           |
+|MSVC 15.8.x       |Aug 14, 2018|        Nov 13, 2023|                           |
+|MSVC 15.7.x       |May  7, 2018|        Aug 14, 2023|                           |
+|MSVC 15.6.x       |Mar  5, 2018|        May  7, 2023|                           |
+|MSVC 15.5.x       |Dec  4, 2017|        Mar  5, 2023|                           |
+|MSVC 15.4.x       |Oct  9, 2017|        Dec  4, 2022|                           |
+|MSVC 15.3.x       |Aug 14, 2017|        Oct  9, 2022|                           |
+|MSVC 15.2.x       |May 10, 2017|        Aug 14, 2022|                           |
+|MSVC 15.1.x       |Apr  5, 2017|        May 10, 2022|                           |
+|MSVC 15.0.x       |Mar  7, 2017|        Apr  5, 2022|std::optional              |
+|MSVC 2015 Update 3|Jun 27, 2016|        Mar  7, 2022|                           |
+|MSVC 2015 Update 2|Mar 30, 2016|        Jun 27, 2021|                           |
+|MSVC 2015 Update 1|Nov 30, 2015|        Mar 30, 2021|                           |
+|MSVC 2015         |Jul 20, 2015|          Deprecated|                           |
 
 |Windows version|Release date|max deprecation date|
 |---------------|-----------:|-------------------:|
 |Windows 10     |Jul 29, 2015|             Current|
-|Windows 8.1    |Oct 17, 2013|        Jul 29, 2020|
-|Windows 8      |Oct 26, 2012|          Deprecated|
+|Windows 8.1    |Oct 17, 2013|          Deprecated|


### PR DESCRIPTION
A new version (or two) of VC has come out. Additionally, time has
passed and the deprecation schedule should reflect both the new VC
versions and deprecate old versions. A new version of Clang has been
released as well.

This commit updates those files.