### PR TITLE
Remove GCC support

### DIFF
--- a/Code/max/Compiling/AliasingOptimizations.hpp
+++ b/Code/max/Compiling/AliasingOptimizations.hpp
@@ -9,16 +9,7 @@
 
 // MAX_PURE_V0
 // Documentation: MAX_PURE.md
-#if defined( MAX_COMPILER_GCC )
-	// this is only available in GCC 2.5 and later
-	#if MAX_COMPILER_VERSION_AT_LEAST( 2, 5, 0 )
-		#define MAX_PURE_DECLARATION_V0( Declaration ) Declaration __attribute__((const))
-		#define MAX_PURE_DEFINITION_V0( Definition ) Definition
-	#else
-		#define MAX_PURE_DECLARATION_V0( Declaration ) Declaration
-		#define MAX_PURE_DEFINITION_V0( Definition ) Definition
-	#endif
-#elif defined( MAX_COMPILER_VC )
+#if defined( MAX_COMPILER_VC )
 	#define MAX_PURE_DECLARATION_V0( Declaration ) __declspec( noalias ) Declaration
 	#define MAX_PURE_DEFINITION_V0( Definition ) __declspec( noalias ) Definition
 #else
@@ -29,16 +20,7 @@
 
 // MAX_PURE_WITH_GLOBALS_V0
 // Documentation: MAX_PURE_WITH_GLOBALS.md
-#if defined( MAX_COMPILER_GCC )
-	// this is only available in GCC 2.96 and later
-	#if MAX_COMPILER_VERSION_AT_LEAST( 2, 96, 0 )
-		#define MAX_PURE_WITH_GLOBALS_DECLARATION_V0( Declaration ) Declaration __attribute__((pure))
-		#define MAX_PURE_WITH_GLOBALS_DEFINITION_V0( Definition ) Definition
-	#else
-		#define MAX_PURE_WITH_GLOBALS_DECLARATION_V0( Declaration ) Declaration
-		#define MAX_PURE_WITH_GLOBALS_DEFINITION_V0( Definition ) Definition
-	#endif
-#elif defined( MAX_COMPILER_VC )
+#if defined( MAX_COMPILER_VC )
 	#define MAX_PURE_WITH_GLOBALS_DECLARATION_V0( Declaration ) __declspec( noalias ) Declaration
 	#define MAX_PURE_WITH_GLOBALS_DEFINITION_V0( Definition ) __declspec( noalias ) Definition
 #else
@@ -60,9 +42,7 @@
 
 // MAX_RESTRICTED_POINTER_V0
 // Documentation: MAX_RESTRICTED_POINTER.md
-#if defined( MAX_COMPILER_GCC )
-	#define MAX_RESTRICTED_POINTER_V0( Type ) Type __restrict__
-#elif defined(MAX_COMPILER_VC)
+#if defined(MAX_COMPILER_VC)
 	#define MAX_RESTRICTED_POINTER_V0( Type ) Type __restrict
 #else
 	#define MAX_RESTRICTED_POINTER_V0( Type ) Type
@@ -71,9 +51,7 @@
 
 // MAX_RESTRICTED_REFERENCE_V0
 // Documentation: MAX_RESTRICTED_REFERENCE.md
-#if defined( MAX_COMPILER_GCC )
-	#define MAX_RESTRICTED_REFERENCE_V0( Type ) __restrict__ Type
-#elif defined( MAX_COMPILER_VC )
+#if defined( MAX_COMPILER_VC )
 	#if MAX_COMPILER_VERSION_AT_LEAST( 14, 0, 0 )
 		#define MAX_RESTRICTED_REFERENCE_V0( Type ) Type __restrict
 	#else
@@ -86,9 +64,7 @@
 
 // MAX_RETURNS_RESTRICTED_POINTER_V0
 // Documentation: MAX_RETURNS_RESTRICTED_POINTER.md
-#if defined( MAX_COMPILER_GCC )
-	#define MAX_RETURNS_RESTRICTED_POINTER_V0( Declaration ) Declaration __attribute__( malloc )
-#elif defined( MAX_COMPILER_VC )
+#if defined( MAX_COMPILER_VC )
 	#define MAX_RETURNS_RESTRICTED_POINTER_V0( Declaration ) __declspec( restrict ) Declaration
 #else
 	#define MAX_RETURNS_RESTRICTED_POINTER_V0( Declaration ) Declaration

--- a/Code/max/Compiling/Alignment.hpp
+++ b/Code/max/Compiling/Alignment.hpp
@@ -11,9 +11,6 @@
 
 #ifdef MAX_COMPILER_VC
 	#define MAX_ALIGN( Expression, Alignment ) __declspec( align( Alignment ) ) Expression
-#elif MAX_COMPILER_GCC
-	#define MAX_ALIGN( Expression, Alignment ) Expression __attribute__((aligned( Alignment ) ))
-#else
 	#error "Unable to align"
 #endif
 

--- a/Code/max/Compiling/Configuration/Compiler.hpp
+++ b/Code/max/Compiling/Configuration/Compiler.hpp
@@ -19,7 +19,7 @@
 	#include <max/Compiling/Configuration/Compiler/Clang.hpp>
 #elif defined __GNUC__
 	// GNU C++
-	#include <max/Compiling/Configuration/Compiler/GCC.hpp>
+	#error "GCC support was deliberately dropped due to non-inclusive behavior from its maintainers."
 #elif defined _MSC_VER
 	// Microsoft Visual C++
 	#include <max/Compiling/Configuration/Compiler/VC.hpp>

--- a/Code/max/Compiling/Configuration/Platform/Linux.hpp
+++ b/Code/max/Compiling/Configuration/Platform/Linux.hpp
@@ -9,7 +9,7 @@
 
 #define MAX_PLATFORM_LINUX
 
-#if defined( MAX_COMPILER_GCC ) || defined( MAX_COMPILER_CLANG )
+#if defined( MAX_COMPILER_CLANG )
 	#if defined( __x86_64__ )
 		#define MAX_64BIT_WORD_SIZE
 		#define MAX_X86_64

--- a/Code/max/Compiling/Configuration/Platform/Win32.hpp
+++ b/Code/max/Compiling/Configuration/Platform/Win32.hpp
@@ -9,23 +9,7 @@
 
 #define MAX_PLATFORM_WINDOWS
 
-#if defined( MAX_COMPILER_GCC )
-	#if defined( __x86_64__ )
-		#define MAX_64BIT_WORD_SIZE
-		#define MAX_X86_64
-		#define MAX_LITTLE_ENDIAN
-	#elif defined( __i386__ )
-		#define MAX_32BIT_WORD_SIZE
-		#define MAX_X86
-		#define MAX_LITTLE_ENDIAN
-	#elif defined( __IA64__ )
-		#define MAX_64BIT_WORD_SIZE
-		#define MAX_IA64
-		#define MAX_LITTLE_ENDIAN
-	#else
-		static_assert( false, "Unknown platform" );
-	#endif
-#elif defined( MAX_COMPILER_VC )
+#if defined( MAX_COMPILER_VC )
 	#if defined( _M_X64 )
 		#define MAX_64BIT_WORD_SIZE
 		#define MAX_X86_64

--- a/Code/max/Compiling/FavorBranchLocality.hpp
+++ b/Code/max/Compiling/FavorBranchLocality.hpp
@@ -11,11 +11,7 @@
 
 #include <max/Compiling/Configuration/Compiler.hpp>
 
-#ifdef MAX_COMPILER_GCC
-	#define MAX_FAVOR_BRANCH_LOCALITY( Expression, ExpectedValue ) __builtin_expect( Expression, ExpectedValue )
-#else
-	#define MAX_FAVOR_BRANCH_LOCALITY( Expression, ExpectedValue ) Expression
-#endif
+#define MAX_FAVOR_BRANCH_LOCALITY( Expression, ExpectedValue ) Expression
 
 #define MAX_FAVOR_TRUE_CASE( Expression ) MAX_FAVOR_BRANCH_LOCALITY( Expression, true )
 #define MAX_FAVOR_FALSE_CASE( Expression ) MAX_FAVOR_BRANCH_LOCALITY( Expression, false )

--- a/Code/max/Compiling/MAX_COMPILER_MESSAGE.md
+++ b/Code/max/Compiling/MAX_COMPILER_MESSAGE.md
@@ -14,4 +14,4 @@ MAX_COMPILER_MESSAGE("Perhaps warn the user that some code is deprecated");
 
 ## Implementation
 
-Go to the separate implementations for [Clang](Configuration/Compiler/Clang.hpp#L12), [GCC](Configuration/Compiler/Clang.hpp#L13), and [MSVC](Configuration/Compiler/Clang.hpp#L10).
+Go to the separate implementations for [Clang](Configuration/Compiler/Clang.hpp#L12) and [MSVC](Configuration/Compiler/Clang.hpp#L10).

--- a/Code/max/Compiling/MemoryBarrier.hpp
+++ b/Code/max/Compiling/MemoryBarrier.hpp
@@ -26,15 +26,4 @@
 	#define FlushReadsAndWrites _ReadWriteBarrier()
 #endif
 
-#ifdef MAX_COMPILER_GCC
-	#error "GCC memory barriers not fully supported yet."
-	#define FlushReads
-	#ifdef MAX_SSE_SUPPORTED
-		#define FlushWrites	__builtin_ia32_sfence()
-	#else
-		#define FlushWrites
-	#endif
-	#define FlushReadsAndWrites
-#endif
-
 #endif // #ifndef MAX_COMPILING_MEMORYBARRIER_HPP

--- a/Code/max/Compiling/NoDefault.hpp
+++ b/Code/max/Compiling/NoDefault.hpp
@@ -10,7 +10,7 @@
 #if defined( NDEBUG )
 	#if defined( MAX_COMPILER_VC )
 		#define MAX_NO_DEFAULT __assume( 0 )
-	#elif defined( MAX_COMPILER_GCC ) | defined( MAX_COMPILER_CLANG )
+	#elif defined( MAX_COMPILER_CLANG )
 		#define MAX_NO_DEFAULT __builtin_unreachable()
 	#else
 		#error "Unsupported compiler"

--- a/Code/max/Hardware/CPU/CPUID.cpp
+++ b/Code/max/Hardware/CPU/CPUID.cpp
@@ -26,7 +26,7 @@
 	#else
 		static_assert( false, "Unsupported platform" );
 	#endif
-#elif defined( MAX_COMPILER_GCC ) || defined( MAX_COMPILER_CLANG )
+#elif defined( MAX_COMPILER_CLANG )
 	#if defined( MAX_X86_64 )
 		#include <max/Hardware/CPU/IsCPUIDAvailablePolicies/X64GCCAssemblyIsCPUIDAvailablePolicy.hpp>
 		#include <max/Hardware/CPU/CPUIDPolicies/X64GCCAssemblyCPUIDPolicy.hpp>
@@ -1282,7 +1282,7 @@ namespace CPU
 		static_assert( false, "Unsupported platform" );
 	#endif
 	typedef VCIntrinsicCPUIDPolicy                  CPUIDPolicy;
-#elif defined( MAX_COMPILER_GCC ) || defined( MAX_COMPILER_CLANG )
+#elif defined( MAX_COMPILER_CLANG )
 	#if defined( MAX_X86_64 )
 		typedef X64GCCAssemblyIsCPUIDAvailablePolicy   IsCPUIDAvailablePolicy;
 		typedef X64GCCAssemblyCPUIDPolicy              CPUIDPolicy;

--- a/Docs/DeprecationSchedule.md
+++ b/Docs/DeprecationSchedule.md
@@ -14,24 +14,6 @@
 |Clang 3.8.x  |Mar  8, 2016|        Sep  2, 2021|                      |
 |Clang 3.7.x  |Sep  1, 2015|          Deprecated|                      |
 
-|GCC version|Release date|max deprecation date|Adds support for                                |
-|-----------|-----------:|-------------------:|------------------------------------------------|
-|GCC 10.2   |Jul 23, 2020|             Current|                                                |
-|GCC 10.1   |May  7, 2020|        Jul 23, 2025|concepts, std::shift_*, constinit               |
-|GCC 9.3    |Mar 12, 2020|        May  7, 2025|                                                |
-|GCC 9.2    |Aug 12, 2019|        Mar 12, 2025|                                                |
-|GCC 9.1    |May  3, 2019|        Aug 12, 2024|<version>, std::assume_aligned(), bit operations|
-|GCC 8.3    |Feb 22, 2019|        May  3, 2024|                                                |
-|GCC 8.2    |Jul 26, 2018|        Feb 22, 2024|std::endian                                     |
-|GCC 7.3    |Jan 25, 2018|        Jul 26, 2023|                                                |
-|GCC 7.2    |Aug 14, 2017|        Jan 25, 2023|                                                |
-|GCC 7.1    |May  2, 2017|        Aug 14, 2023|std::optional                                   |
-|GCC 6.3    |Dec 21, 2016|        May  2, 2022|                                                |
-|GCC 6.2    |Aug 22, 2016|        Dec 21, 2021|                                                |
-|GCC 6.1    |Apr 27, 2016|        Aug 22, 2021|                                                |
-|GCC 5.3    |Dec  4, 2015|        Apr 27, 2021|                                                |
-|GCC 5.2    |Jul 16, 2015|          Deprecated|                                                |
-
 |MSVC version      |Release date|max deprecation date|Adds support for           |
 |------------------|-----------:|-------------------:|---------------------------|
 |MSVC 16.8.x       |Nov 10, 2020|             Current|modules, coroutines, ranges|

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -14,7 +14,6 @@ It includes common code such as logging, testing, abstractions for compiler and 
 ## Support
 
 * Compilers:
-    * GCC
     * Clang
     * Visual C++
 * OSes:
@@ -30,6 +29,7 @@ It includes common code such as logging, testing, abstractions for compiler and 
 *Coming soon
 
 If you would like max to support more contacts us and let us know.
+Note, GCC support was deliberately dropped due to non-inclusive behavior from its maintainers.
 
 ## Deprecation Schedule
 

--- a/Projects/VisualStudio/max/max.vcxproj
+++ b/Projects/VisualStudio/max/max.vcxproj
@@ -102,7 +102,6 @@
     </ClInclude>
     <ClInclude Include="..\..\..\Code\max\Compiling\Configuration\Compiler.hpp" />
     <ClInclude Include="..\..\..\Code\max\Compiling\Configuration\Compiler\Clang.hpp" />
-    <ClInclude Include="..\..\..\Code\max\Compiling\Configuration\Compiler\GCC.hpp" />
     <ClInclude Include="..\..\..\Code\max\Compiling\Configuration\Compiler\VC.hpp" />
     <ClInclude Include="..\..\..\Code\max\Compiling\Configuration\Platform.hpp" />
     <ClInclude Include="..\..\..\Code\max\Compiling\Configuration\Platform\Android.hpp" />

--- a/Projects/VisualStudio/max/max.vcxproj.filters
+++ b/Projects/VisualStudio/max/max.vcxproj.filters
@@ -209,9 +209,6 @@
     <ClInclude Include="..\..\..\Code\max\Compiling\Configuration\Compiler\Clang.hpp">
       <Filter>Code\max\Compiling\Configuration\Compiler</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\Code\max\Compiling\Configuration\Compiler\GCC.hpp">
-      <Filter>Code\max\Compiling\Configuration\Compiler</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\Code\max\Compiling\Configuration\Compiler\VC.hpp">
       <Filter>Code\max\Compiling\Configuration\Compiler</Filter>
     </ClInclude>


### PR DESCRIPTION
GCC is maintained by the Free Software Foundation, which has
supported non-inclusive behavior.

This is against our code of conduct and not the direction our
industry should be headed. As a result, max will not support GCC.
And thus will not indirectly support non-inclusive behavior.

This commit removes GCC support.