### PR TITLE
Update deprecation schedule

### DIFF
--- a/Code/max/Compiling/FavorBranchLocality.hpp
+++ b/Code/max/Compiling/FavorBranchLocality.hpp
@@ -17,6 +17,13 @@
 	#define MAX_FAVOR_BRANCH_LOCALITY( Expression, ExpectedValue ) Expression
 #endif
 
+#if __has_cpp_attribute(likely)
+#define MAX_FAVOR_TRUE_CASE( Expression ) Expression [[likely]]
+#endif
+#if __has_cpp_attribute(unlikely)
+#define MAX_FAVOR_FALSE_CASE( Expression ) Expression [[unlikely]]
+#endif
+
 #define MAX_FAVOR_TRUE_CASE( Expression ) MAX_FAVOR_BRANCH_LOCALITY( Expression, true )
 #define MAX_FAVOR_FALSE_CASE( Expression ) MAX_FAVOR_BRANCH_LOCALITY( Expression, false )
 

--- a/Docs/DeprecationSchedule.md
+++ b/Docs/DeprecationSchedule.md
@@ -1,22 +1,25 @@
 # max deprecation schedule
 
-|Clang version|Release date|max deprecation date|Adds support for      |
-|-------------|-----------:|-------------------:|----------------------|
-|Clang 11.0.x |Oct 12, 2020|             Current|                      |
-|Clang 10.0.x |Mar 24, 2020|        Oct 12, 2025|concepts, constinit   |
-|Clang 9.0.x  |Sep 19, 2019|        Mar 24, 2025|bit operations        |
-|Clang 8.0.x  |Mar 20, 2019|        Sep 19, 2024|                      |
-|Clang 7.0.x  |Sep 19, 2018|        Mar 20, 2024|std::endian, <version>|
-|Clang 6.0.x  |Mar  8, 2018|        Sep 19, 2023|                      |
-|Clang 5.0.x  |Sep  7, 2018|        Mar  8, 2023|                      |
-|Clang 4.0.x  |Mar 13, 2017|        Sep  7, 2023|std::optional         |
-|Clang 3.9.x  |Sep  2, 2016|        Mar 13, 2022|                      |
-|Clang 3.8.x  |Mar  8, 2016|        Sep  2, 2021|                      |
-|Clang 3.7.x  |Sep  1, 2015|          Deprecated|                      |
+|Clang version|Release date|max deprecation date|Adds support for                    |
+|-------------|-----------:|-------------------:|------------------------------------|
+|Clang 12.0.x |Apr 15, 2021|             Current|constexpr bit intrinsics, [[likely]]|
+|Clang 11.0.x |Oct 12, 2020|        Apr 15, 2026|                                    |
+|Clang 10.0.x |Mar 24, 2020|        Oct 12, 2025|concepts, constinit                 |
+|Clang 9.0.x  |Sep 19, 2019|        Mar 24, 2025|bit operations                      |
+|Clang 8.0.x  |Mar 20, 2019|        Sep 19, 2024|                                    |
+|Clang 7.0.x  |Sep 19, 2018|        Mar 20, 2024|std::endian, <version>              |
+|Clang 6.0.x  |Mar  8, 2018|        Sep 19, 2023|                                    |
+|Clang 5.0.x  |Sep  7, 2018|        Mar  8, 2023|                                    |
+|Clang 4.0.x  |Mar 13, 2017|        Sep  7, 2023|std::optional                       |
+|Clang 3.9.x  |Sep  2, 2016|        Mar 13, 2022|                                    |
+|Clang 3.8.x  |Mar  8, 2016|        Sep  2, 2021|                                    |
+|Clang 3.7.x  |Sep  1, 2015|          Deprecated|                                    |
 
 |GCC version|Release date|max deprecation date|Adds support for                                |
 |-----------|-----------:|-------------------:|------------------------------------------------|
-|GCC 10.2   |Jul 23, 2020|             Current|                                                |
+|GCC 11.1   |Apr 27, 2021|             Current|std::bit_cast                                   |
+|GCC 10.3   |Apr  4, 2021|        Apr 27, 2026|                                                |
+|GCC 10.2   |Jul 23, 2020|        Apr  4, 2026|                                                |
 |GCC 10.1   |May  7, 2020|        Jul 23, 2025|concepts, std::shift_*, constinit               |
 |GCC 9.3    |Mar 12, 2020|        May  7, 2025|                                                |
 |GCC 9.2    |Aug 12, 2019|        Mar 12, 2025|                                                |
@@ -29,12 +32,13 @@
 |GCC 6.3    |Dec 21, 2016|        May  2, 2022|                                                |
 |GCC 6.2    |Aug 22, 2016|        Dec 21, 2021|                                                |
 |GCC 6.1    |Apr 27, 2016|        Aug 22, 2021|                                                |
-|GCC 5.3    |Dec  4, 2015|        Apr 27, 2021|                                                |
-|GCC 5.2    |Jul 16, 2015|          Deprecated|                                                |
+|GCC 5.3    |Dec  4, 2015|          Deprecated|                                                |
 
 |MSVC version      |Release date|max deprecation date|Adds support for           |
 |------------------|-----------:|-------------------:|---------------------------|
-|MSVC 16.8.x       |Nov 10, 2020|             Current|modules, coroutines, ranges|
+|MSVC 16.10.x      |May 25, 2021|             Current|                           |
+|MSVC 16.9.x       |Mar  2, 2021|        May 25, 2026|                           |
+|MSVC 16.8.x       |Nov 10, 2020|        Mar  2, 2026|modules, coroutines, ranges|
 |MSVC 16.7.x       |Aug  5, 2020|        Nov 10, 2025|                           |
 |MSVC 16.6.x       |May 19, 2020|        Aug  5, 2025|                           |
 |MSVC 16.5.x       |Mar 16, 2020|        May 19, 2025|bit operations             |
@@ -54,9 +58,7 @@
 |MSVC 15.1.x       |Apr  5, 2017|        May 10, 2022|                           |
 |MSVC 15.0.x       |Mar  7, 2017|        Apr  5, 2022|std::optional              |
 |MSVC 2015 Update 3|Jun 27, 2016|        Mar  7, 2022|                           |
-|MSVC 2015 Update 2|Mar 30, 2016|        Jun 27, 2021|                           |
-|MSVC 2015 Update 1|Nov 30, 2015|        Mar 30, 2021|                           |
-|MSVC 2015         |Jul 20, 2015|          Deprecated|                           |
+|MSVC 2015 Update 2|Mar 30, 2016|          Deprecated|                           |
 
 |Windows version|Release date|max deprecation date|
 |---------------|-----------:|-------------------:|


### PR DESCRIPTION
Time has passed. New compiler versions have come out. Old ones are
now deprecated.

This PR updates the deprecation schedule.
(It also apparently resolves a conflict in FavorBranchLocality.hpp?)