### PR TITLE
Don't list all special members

### DIFF
--- a/Code/max/Containers/Vector.hpp
+++ b/Code/max/Containers/Vector.hpp
@@ -24,12 +24,6 @@ namespace Containers
 
 		Vector() noexcept = default;
 		Vector( const std::initializer_list< T > & rhs ) noexcept;
-		Vector( const Vector< T, Dimensions > & rhs ) noexcept = default;
-		Vector( Vector< T, Dimensions > && rhs ) noexcept = default;
-		~Vector() noexcept = default;
-
-		Vector< T, Dimensions > & operator =( const Vector< T, Dimensions > & rhs ) noexcept = default;
-		Vector< T, Dimensions > & operator =( Vector< T, Dimensions > && rhs ) noexcept = default;
 
 		Vector< T, Dimensions > operator +( const Vector< T, Dimensions > & rhs ) const noexcept;
 		Vector< T, Dimensions > operator -( const Vector< T, Dimensions > & rhs ) const noexcept;

--- a/Code/max/Containers/Vector.inl
+++ b/Code/max/Containers/Vector.inl
@@ -15,6 +15,7 @@ namespace Containers
 	Vector< T, Dimensions >::Vector( const std::initializer_list< T > & rhs ) noexcept
 		: Elements()
 	{
+		// TODO: Check bounds
 		std::copy( rhs.begin(), rhs.end(), Elements.begin() );
 	}
 

--- a/Code/max/Hardware/CPU/Associativity.hpp
+++ b/Code/max/Hardware/CPU/Associativity.hpp
@@ -24,13 +24,6 @@ namespace CPU
 		explicit Associativity( const UnknownAssociativity )         noexcept;
 		explicit Associativity( const FullyAssociative )             noexcept;
 		explicit Associativity( const uint32_t WaysOfAssociativity ) noexcept;
-		Associativity()                                              noexcept = delete;
-		Associativity( const Associativity & rhs )                   noexcept = default;
-		Associativity( Associativity && rhs )                        noexcept = default;
-		~Associativity()                                             noexcept = default;
-
-		Associativity & operator =( const Associativity & rhs ) noexcept = default;
-		Associativity & operator =( Associativity && rhs )      noexcept = default;
 
 		bool IsUnknown()               const noexcept;
 		bool IsFullyAssociative()      const noexcept;

--- a/Code/max/Hardware/CPU/CPUID.cpp
+++ b/Code/max/Hardware/CPU/CPUID.cpp
@@ -598,7 +598,7 @@ namespace CPU
 		{
 			uint32_t MaxSubleaf = 0;
 
-			for( auto CurrentSubleaf : SubleafResults )
+			for( const auto & CurrentSubleaf : SubleafResults )
 			{
 				if( CurrentSubleaf.Leaf == Leaf )
 				{

--- a/Code/max/Hardware/CPU/CPUID.hpp
+++ b/Code/max/Hardware/CPU/CPUID.hpp
@@ -20,13 +20,6 @@ namespace CPU
 	{
 	public:
 
-		CPUID()                                  noexcept = delete;
-		CPUID( const CPUID &  rhs )                       = default;
-		CPUID(       CPUID && rhs )              noexcept = default;
-
-		CPUID & operator =( const CPUID &  rhs )          = default;
-		CPUID & operator =(       CPUID && rhs ) noexcept = default;
-
 		// Function 0
 		std::string Vendor()              const noexcept;
 

--- a/Code/max/Hardware/CPU/CPUIDSubleafArgumentsAndResult.hpp
+++ b/Code/max/Hardware/CPU/CPUIDSubleafArgumentsAndResult.hpp
@@ -19,15 +19,8 @@ namespace CPU
 
 		CPUIDSubleafArgumentsAndResult( const uint32_t Leaf,
 		                                const uint32_t Subleaf,
-		                                CPUIDSubleafResult && Result )                            noexcept;
-		CPUIDSubleafArgumentsAndResult()                                                          noexcept = default; // TODO: make this = delete
-		CPUIDSubleafArgumentsAndResult( const CPUIDSubleafArgumentsAndResult & rhs )              noexcept = default;
-		CPUIDSubleafArgumentsAndResult( CPUIDSubleafArgumentsAndResult && rhs )                   noexcept = default;
-		~CPUIDSubleafArgumentsAndResult()                                                         noexcept = default;
-
-		CPUIDSubleafArgumentsAndResult & operator =( const CPUIDSubleafArgumentsAndResult & rhs ) noexcept = default;
-		CPUIDSubleafArgumentsAndResult & operator =( CPUIDSubleafArgumentsAndResult && rhs )      noexcept = default;
-
+		                                CPUIDSubleafResult && Result ) noexcept;
+		CPUIDSubleafArgumentsAndResult() noexcept = default; // TODO: make this = delete
 
 		uint32_t Leaf;
 		uint32_t Subleaf;

--- a/Code/max/Hardware/CPU/CacheInfo.hpp
+++ b/Code/max/Hardware/CPU/CacheInfo.hpp
@@ -31,14 +31,7 @@ namespace CPU
 			Unified
 		};
 
-		explicit CacheInfo( CacheInfoType Type )        noexcept;
-		CacheInfo()                                     noexcept = delete;
-		CacheInfo( const CacheInfo & rhs)               noexcept = default;
-		CacheInfo( CacheInfo && rhs)                    noexcept = default;
-		~CacheInfo()                                    noexcept = default;
-
-		CacheInfo & operator =( const CacheInfo & rhs ) noexcept = default;
-		CacheInfo & operator =( CacheInfo && rhs )      noexcept = default;
+		explicit CacheInfo( CacheInfoType Type ) noexcept;
 
 		CacheInfoType Type;
 

--- a/Code/max/Hardware/CPU/CacheLevel.hpp
+++ b/Code/max/Hardware/CPU/CacheLevel.hpp
@@ -24,13 +24,6 @@ namespace CPU
 		            const Associativity &    AssociativityInfo,
 		            const uint32_t           CacheLineSizeInBytes,
 		            const uint32_t           CacheLinesPerSector   ) noexcept;
-		CacheLevel()                                      noexcept = delete;
-		CacheLevel( const CacheLevel & rhs )              noexcept = default;
-		CacheLevel( CacheLevel && rhs )                   noexcept = default;
-		~CacheLevel()                                     noexcept = default;
-
-		CacheLevel & operator =( const CacheLevel & rhs ) noexcept = default;
-		CacheLevel & operator =( CacheLevel && rhs )      noexcept = default;
 
 		CacheContentType   ContentType;
 		uint32_t           Level;

--- a/Code/max/Hardware/CPU/Prefetch.hpp
+++ b/Code/max/Hardware/CPU/Prefetch.hpp
@@ -18,13 +18,6 @@ namespace CPU
 	public:
 
 		explicit Prefetch( const uint32_t SizeInBytes ) noexcept;
-		Prefetch()                                      noexcept = delete;
-		Prefetch( const Prefetch & rhs )                noexcept = default;
-		Prefetch( Prefetch && rhs )                     noexcept = default;
-		~Prefetch()                                     noexcept = default;
-
-		Prefetch & operator =( const Prefetch & rhs )   noexcept = default;
-		Prefetch & operator =( Prefetch && rhs )        noexcept = default;
 
 		uint32_t SizeInBytes;
 

--- a/Code/max/Hardware/CPU/TLB.hpp
+++ b/Code/max/Hardware/CPU/TLB.hpp
@@ -23,13 +23,6 @@ namespace CPU
 		TLBConfiguration(       std::vector< uint32_t  > && PageSizesInBytes,
 		                  const Associativity &             AssociativityInfo,
 		                  const uint32_t                    EntryCount        ) noexcept;
-		TLBConfiguration()                                                      noexcept = delete;
-		TLBConfiguration( const TLBConfiguration & rhs )                                 = default;
-		TLBConfiguration( TLBConfiguration && rhs )                             noexcept = default;
-		~TLBConfiguration()                                                     noexcept = default;
-
-		TLBConfiguration & operator =( const TLBConfiguration & rhs )                    = default;
-		TLBConfiguration & operator =( TLBConfiguration && rhs )                noexcept = default;
 
 		std::vector< uint32_t  >      PageSizesInBytes;
 		Associativity                 AssociativityInfo;
@@ -43,13 +36,6 @@ namespace CPU
 
 		TLB( const CacheContentType                   ContentType,
 		           std::vector< TLBConfiguration > && Configurations ) noexcept;
-		TLB()                                                          noexcept = delete;
-		TLB( const TLB & rhs )                                                  = default;
-		TLB( TLB && rhs )                                              noexcept = default;
-		~TLB()                                                         noexcept = default;
-
-		TLB & operator =( const TLB & rhs )                                     = default;
-		TLB & operator =( TLB && rhs )                                 noexcept = default;
 
 		CacheContentType ContentType;
 		std::vector< TLBConfiguration > Configurations;

--- a/Code/max/Hardware/CPU/TraceCache.hpp
+++ b/Code/max/Hardware/CPU/TraceCache.hpp
@@ -20,13 +20,6 @@ namespace CPU
 
 		TraceCache( const uint32_t        SizeInMicroOperations,
 		            const Associativity & AssociativityInfo    ) noexcept;
-		TraceCache()                                             noexcept = delete;
-		TraceCache( const TraceCache & rhs )                     noexcept = default;
-		TraceCache( TraceCache && rhs )                          noexcept = default;
-		~TraceCache()                                            noexcept = default;
-
-		TraceCache & operator =( const TraceCache & rhs )        noexcept = default;
-		TraceCache & operator =( TraceCache && rhs )             noexcept = default;
 
 		uint32_t      SizeInMicroOperations;
 		Associativity AssociativityInfo;


### PR DESCRIPTION
This commit relies on Howard Hinnant's chart of special member functions
that are generated in a given situation [1]. There is also a presentation of
it [2].

Rather than spell out every function with =default, only =default it
when needed.

[1] https://howardhinnant.github.io/classdecl.html
[2] https://www.youtube.com/watch?v=vLinb2fgkHk