### PR TITLE
Update AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,1 @@
-Chris Blume cblume@google.com
+Chris Blume ProgramMax@gmail.com


### PR DESCRIPTION
Chris Blume has retired from Google. We should no longer use his
@google.com email address.

This commit updates his entry to reflect his current email address.