### PR TITLE
Add perf monitoring

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -61,6 +61,8 @@ jobs:
     # TODO: Should this use perf stat record?
     - name: Performance Test
       run: perf stat ${{ github.workspace }}/Projects/${{ matrix.compiler }}\ ${{ matrix.platform }}\ Make/maxAutomatedTests > perf_stats
+
+    - name: Upload performance test artifact
       uses: actions/upload-artifact@v3
       with:
         name: perf_stats

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -59,10 +59,12 @@ jobs:
       run: ${{ github.workspace }}/Projects/${{ matrix.compiler }}\ ${{ matrix.platform }}\ Make/maxAutomatedTests
 
     # TODO: Should this use perf stat record?
-    - name: Performance Test
-      run: perf stat ${{ github.workspace }}/Projects/${{ matrix.compiler }}\ ${{ matrix.platform }}\ Make/maxAutomatedTests > perf_stats
+    # TODO: GitHub won't let us run perf stat on their machines. That is fine, really. We should host our own stable hardware.
+    # Disable until we are hosting our own.
+    #- name: Performance Test
+    #  run: perf stat ${{ github.workspace }}/Projects/${{ matrix.compiler }}\ ${{ matrix.platform }}\ Make/maxAutomatedTests > perf_stats
 
-    - name: Upload performance test artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: perf_stats
+    #- name: Upload performance test artifact
+    #  uses: actions/upload-artifact@v3
+    #  with:
+    #    name: perf_stats

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -57,3 +57,10 @@ jobs:
 
     - name: Test
       run: ${{ github.workspace }}/Projects/${{ matrix.compiler }}\ ${{ matrix.platform }}\ Make/maxAutomatedTests
+
+    # TODO: Should this use perf stat record?
+    - name: Performance Test
+      run: perf stat ${{ github.workspace }}/Projects/${{ matrix.compiler }}\ ${{ matrix.platform }}\ Make/maxAutomatedTests > perf_stats
+      uses: actions/upload-artifact@v3
+      with:
+        name: perf_stats


### PR DESCRIPTION
This commit adds a call to perf to the CI. It then stores the results of that perf run as an artifact, allowing a comparison between tip-of-tree and a pull request.