### PR TITLE
Add old compilers to CI

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -48,8 +48,8 @@ jobs:
     - name: Install Compiler
       run: |
            sudo apt update
-           apt search clang
-           apt search g++
+           apt search --names-only clang
+           apt search --names-only g++
            sudo apt install ${{ matrix.compiler }}
            set CXX ${{ matrix.compiler }}
            ${{ matrix.compiler }} --version

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         platform: [X86-64] # TODO: Add X86, AArch32, and AArch64 platforms
-        compiler: [clang++, g++]
+        compiler: [clang++, g++-9, g++-10, g++-11, g++-12]
         runner: [ubuntu-22.04, ubuntu-20.04]
     runs-on: ${{ matrix.runner }}
 
@@ -44,10 +44,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    #- name: Install Compilers
-    #  run: |
-    #       sudo apt update
-    #       sudo apt install g++-9 g++-10 llvm-10 clang-10
+    - name: Install Compiler
+      run: |
+           sudo apt update
+           sudo apt install ${{ matrix.compiler }}
+           set CXX ${{ matrix.compiler }}
+           ${{ matrix.compiler }} --version
 
     - name: Build
       env:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -36,7 +36,8 @@ jobs:
     strategy:
       matrix:
         platform: [X86-64] # TODO: Add X86, AArch32, and AArch64 platforms
-        compiler: [clang-4, clang-5, clang-6, clang-7, clang-8, clang-9, clang-10, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16, g++-7, g++-8, g++-9, g++-10, g++-11, g++-12]
+        #compiler: [clang-4, clang-5, clang-6, clang-7, clang-8, clang-9, clang-10, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16, g++-7, g++-8, g++-9, g++-10, g++-11, g++-12]
+        compiler: [g++-7, g++-8, g++-9, g++-10, g++-11, g++-12]
         runner: [ubuntu-22.04, ubuntu-20.04]
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -39,6 +39,8 @@ jobs:
         compiler: [clang-11, clang-12, gcc-7, gcc-8, gcc-9, gcc-10, gcc-11, gcc-12]
         runner: [ubuntu-22.04, ubuntu-20.04]
         include:
+          - runner: ubuntu-20.04
+            compiler: [clang-6, clang-7, clang-8, clang-9, clang-10]
           - runner: ubuntu-22.04
             compiler: [clang-13, clang-14]
     runs-on: ${{ matrix.runner }}
@@ -50,7 +52,7 @@ jobs:
     - name: Install Compiler
       run: |
            sudo apt update
-           apt search ^clang
+           apt search ^gcc
            sudo apt install ${{ matrix.compiler }}
            set CXX ${{ matrix.compiler }}
            ${{ matrix.compiler }} --version

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -48,8 +48,7 @@ jobs:
     - name: Install Compiler
       run: |
            sudo apt update
-           apt search --names-only clang
-           apt search --names-only g++
+           apt search ^clang$
            sudo apt install ${{ matrix.compiler }}
            set CXX ${{ matrix.compiler }}
            ${{ matrix.compiler }} --version

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -75,8 +75,8 @@ jobs:
            sudo apt remove clang
            apt search ^clang
            sudo apt install ${{ matrix.compiler }}
-           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${{ matrix.compiler }} 50
-           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/${{ matrix.compiler }} 50
+           #sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${{ matrix.compiler }} 50
+           #sudo update-alternatives --install /usr/bin/clang clang /usr/bin/${{ matrix.compiler }} 50
            #set CXX ${{ matrix.compiler }}
            ${{ matrix.compiler }} --version
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -71,6 +71,7 @@ jobs:
     - name: Install Compiler
       run: |
            sudo apt update
+           apt search ^clang
            sudo apt install ${{ matrix.compiler }}
            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${{ matrix.compiler }} 50
            sudo update-alternatives --install /usr/bin/clang clang /usr/bin/${{ matrix.compiler }} 50

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Compiler
       run: |
            sudo apt update
-           apt search ^g++$
+           apt search ^gcc$
            sudo apt install ${{ matrix.compiler }}
            set CXX ${{ matrix.compiler }}
            ${{ matrix.compiler }} --version

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         platform: [X86-64] # TODO: Add X86, AArch32, and AArch64 platforms
-        compiler: [clang-11, clang-12, gcc-9, gcc-10, gcc-11, gcc-12]
+        compiler: [clang-11, clang-12, gcc-9, gcc-10, gcc-11]
         runner: [ubuntu-22.04, ubuntu-20.04]
         include:
           - runner: ubuntu-20.04
@@ -57,6 +57,8 @@ jobs:
             compiler: clang-13
           - runner: ubuntu-22.04
             compiler: clang-14
+          - runner: ubuntu-22.04
+            compiler: gcc-12
     runs-on: ${{ matrix.runner }}
 
     steps:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -41,14 +41,21 @@ jobs:
         include:
           - runner: ubuntu-20.04
             compiler: clang-6
+          - runner: ubuntu-20.04
             compiler: clang-7
+          - runner: ubuntu-20.04
             compiler: clang-8
+          - runner: ubuntu-20.04
             compiler: clang-9
+          - runner: ubuntu-20.04
             compiler: clang-10
+          - runner: ubuntu-20.04
             compiler: gcc-7
+          - runner: ubuntu-20.04
             compiler: gcc-8
           - runner: ubuntu-22.04
             compiler: clang-13
+          - runner: ubuntu-22.04
             compiler: clang-14
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         platform: [X86-64] # TODO: Add X86, AArch32, and AArch64 platforms
-        compiler: [clang++, g++-9, g++-10, g++-11, g++-12]
+        compiler: [clang-4, clang-5, clang-6, clang-7, clang-8, clang-9, clang-10, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16, g++-7, g++-8, g++-9, g++-10, g++-11, g++-12]
         runner: [ubuntu-22.04, ubuntu-20.04]
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -71,8 +71,8 @@ jobs:
     - name: Install Compiler
       run: |
            sudo apt update
-           sudo apt uninstall gcc
-           sudo apt uninstall clang
+           sudo apt remove gcc
+           sudo apt remove clang
            apt search ^clang
            sudo apt install ${{ matrix.compiler }}
            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${{ matrix.compiler }} 50

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         platform: [X86-64] # TODO: Add X86, AArch32, and AArch64 platforms
         #compiler: [clang-4, clang-5, clang-6, clang-7, clang-8, clang-9, clang-10, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16, g++-7, g++-8, g++-9, g++-10, g++-11, g++-12]
-        compiler: [g++-7, g++-8, g++-9, g++-10, g++-11, g++-12]
+        compiler: [gcc-7, gcc-8, gcc-9, gcc-10, gcc-11, gcc-12]
         runner: [ubuntu-22.04, ubuntu-20.04]
     runs-on: ${{ matrix.runner }}
 
@@ -48,7 +48,7 @@ jobs:
     - name: Install Compiler
       run: |
            sudo apt update
-           apt search ^gcc
+           apt search ^clang
            sudo apt install ${{ matrix.compiler }}
            set CXX ${{ matrix.compiler }}
            ${{ matrix.compiler }} --version

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Compiler
       run: |
            sudo apt update
-           apt search ^gcc$
+           apt search ^gcc
            sudo apt install ${{ matrix.compiler }}
            set CXX ${{ matrix.compiler }}
            ${{ matrix.compiler }} --version

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -71,8 +71,8 @@ jobs:
     - name: Install Compiler
       run: |
            sudo apt update
-           apt search ^gcc
            sudo apt install ${{ matrix.compiler }}
+           sudo update-alternatives --install /usr/bin/gcc /usr/bin/${{ matrix.compiler }} 50
            set CXX ${{ matrix.compiler }}
            ${{ matrix.compiler }} --version
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -73,9 +73,9 @@ jobs:
            sudo apt update
            sudo apt remove gcc
            sudo apt remove clang
-           sudo update-alternatives --remove-all gcc
-           sudo update-alternatives --remove-all g++
-           sudo update-alternatives --remove-all clang
+           #sudo update-alternatives --remove-all gcc
+           #sudo update-alternatives --remove-all g++
+           #sudo update-alternatives --remove-all clang
            apt search ^clang
            sudo apt install ${{ matrix.compiler }}
            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${{ matrix.compiler }} 50
@@ -85,7 +85,8 @@ jobs:
 
     - name: Build
       env:
-        CXX: ${{ matrix.compiler }}
+        #CXX: ${{ matrix.compiler }}
+        CXX: gcc
       working-directory: ${{ github.workspace }}/Projects/Make
       run: make
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -77,12 +77,12 @@ jobs:
            sudo apt install ${{ matrix.compiler }}
            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${{ matrix.compiler }} 50
            sudo update-alternatives --install /usr/bin/clang clang /usr/bin/${{ matrix.compiler }} 50
-           set CXX ${{ matrix.compiler }}
+           #set CXX ${{ matrix.compiler }}
            ${{ matrix.compiler }} --version
 
     - name: Build
-      env:
-        CXX: ${{ matrix.compiler }}
+      #env:
+      #  CXX: ${{ matrix.compiler }}
       working-directory: ${{ github.workspace }}/Projects/Make
       run: make
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         platform: [X86-64] # TODO: Add X86, AArch32, and AArch64 platforms
-        compiler: [clang-6, clang-11, clang-12, gcc-9, gcc-10, gcc-11]
+        compiler: [clang-11, clang-12, gcc-9, gcc-10, gcc-11]
         runner: [ubuntu-22.04, ubuntu-20.04]
         exclude:
           - runner: ubuntu-22.04

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -36,8 +36,7 @@ jobs:
     strategy:
       matrix:
         platform: [X86-64] # TODO: Add X86, AArch32, and AArch64 platforms
-        #compiler: [clang-4, clang-5, clang-6, clang-7, clang-8, clang-9, clang-10, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16, g++-7, g++-8, g++-9, g++-10, g++-11, g++-12]
-        compiler: [gcc-7, gcc-8, gcc-9, gcc-10, gcc-11, gcc-12]
+        compiler: [clang-11, clang-12, clang-13, clang-14, gcc-7, gcc-8, gcc-9, gcc-10, gcc-11, gcc-12]
         runner: [ubuntu-22.04, ubuntu-20.04]
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -36,29 +36,32 @@ jobs:
     strategy:
       matrix:
         platform: [X86-64] # TODO: Add X86, AArch32, and AArch64 platforms
-        compiler: [clang-11, clang-12, gcc-9, gcc-10, gcc-11]
+        compiler: [clang-6, clang-11, clang-12, gcc-9, gcc-10, gcc-11]
         runner: [ubuntu-22.04, ubuntu-20.04]
-        include:
-          - runner: ubuntu-20.04
+        exclude:
+          - runner: ubuntu-22.04
             compiler: clang-6
-          - runner: ubuntu-20.04
-            compiler: clang-7
-          - runner: ubuntu-20.04
-            compiler: clang-8
-          - runner: ubuntu-20.04
-            compiler: clang-9
-          - runner: ubuntu-20.04
-            compiler: clang-10
-          - runner: ubuntu-20.04
-            compiler: gcc-7
-          - runner: ubuntu-20.04
-            compiler: gcc-8
-          - runner: ubuntu-22.04
-            compiler: clang-13
-          - runner: ubuntu-22.04
-            compiler: clang-14
-          - runner: ubuntu-22.04
-            compiler: gcc-12
+        #include:
+        #  - runner: ubuntu-20.04
+        #    compiler: clang-6
+        #  - runner: ubuntu-20.04
+        #    compiler: clang-7
+        #  - runner: ubuntu-20.04
+        #    compiler: clang-8
+        #  - runner: ubuntu-20.04
+        #    compiler: clang-9
+        #  - runner: ubuntu-20.04
+        #    compiler: clang-10
+        #  - runner: ubuntu-20.04
+        #    compiler: gcc-7
+        #  - runner: ubuntu-20.04
+        #    compiler: gcc-8
+        #  - runner: ubuntu-22.04
+        #    compiler: clang-13
+        #  - runner: ubuntu-22.04
+        #    compiler: clang-14
+        #  - runner: ubuntu-22.04
+        #    compiler: gcc-12
     runs-on: ${{ matrix.runner }}
 
     steps:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Compiler
       run: |
            sudo apt update
-           apt search ^clang$
+           apt search ^g++$
            sudo apt install ${{ matrix.compiler }}
            set CXX ${{ matrix.compiler }}
            ${{ matrix.compiler }} --version

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -36,13 +36,20 @@ jobs:
     strategy:
       matrix:
         platform: [X86-64] # TODO: Add X86, AArch32, and AArch64 platforms
-        compiler: [clang-11, clang-12, gcc-7, gcc-8, gcc-9, gcc-10, gcc-11, gcc-12]
+        compiler: [clang-11, clang-12, gcc-9, gcc-10, gcc-11, gcc-12]
         runner: [ubuntu-22.04, ubuntu-20.04]
         include:
           - runner: ubuntu-20.04
-            compiler: [clang-6, clang-7, clang-8, clang-9, clang-10]
+            compiler: clang-6
+            compiler: clang-7
+            compiler: clang-8
+            compiler: clang-9
+            compiler: clang-10
+            compiler: gcc-7
+            compiler: gcc-8
           - runner: ubuntu-22.04
-            compiler: [clang-13, clang-14]
+            compiler: clang-13
+            compiler: clang-14
     runs-on: ${{ matrix.runner }}
 
     steps:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -81,8 +81,8 @@ jobs:
            ${{ matrix.compiler }} --version
 
     - name: Build
-      #env:
-      #  CXX: ${{ matrix.compiler }}
+      env:
+        CXX: ${{ matrix.compiler }}
       working-directory: ${{ github.workspace }}/Projects/Make
       run: make
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -36,8 +36,11 @@ jobs:
     strategy:
       matrix:
         platform: [X86-64] # TODO: Add X86, AArch32, and AArch64 platforms
-        compiler: [clang-11, clang-12, clang-13, clang-14, gcc-7, gcc-8, gcc-9, gcc-10, gcc-11, gcc-12]
+        compiler: [clang-11, clang-12, gcc-7, gcc-8, gcc-9, gcc-10, gcc-11, gcc-12]
         runner: [ubuntu-22.04, ubuntu-20.04]
+        include:
+          - runner: ubuntu-22.04
+            compiler: [clang-13, clang-14]
     runs-on: ${{ matrix.runner }}
 
     steps:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -71,6 +71,8 @@ jobs:
     - name: Install Compiler
       run: |
            sudo apt update
+           sudo apt uninstall gcc
+           sudo apt uninstall clang
            apt search ^clang
            sudo apt install ${{ matrix.compiler }}
            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${{ matrix.compiler }} 50

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -73,6 +73,9 @@ jobs:
            sudo apt update
            sudo apt remove gcc
            sudo apt remove clang
+           sudo update-alternatives --remove-all gcc
+           sudo update-alternatives --remove-all g++
+           sudo update-alternatives --remove-all clang
            apt search ^clang
            sudo apt install ${{ matrix.compiler }}
            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${{ matrix.compiler }} 50

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -48,6 +48,8 @@ jobs:
     - name: Install Compiler
       run: |
            sudo apt update
+           apt search clang
+           apt search g++
            sudo apt install ${{ matrix.compiler }}
            set CXX ${{ matrix.compiler }}
            ${{ matrix.compiler }} --version

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -72,7 +72,8 @@ jobs:
       run: |
            sudo apt update
            sudo apt install ${{ matrix.compiler }}
-           sudo update-alternatives --install /usr/bin/gcc /usr/bin/${{ matrix.compiler }} 50
+           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${{ matrix.compiler }} 50
+           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/${{ matrix.compiler }} 50
            set CXX ${{ matrix.compiler }}
            ${{ matrix.compiler }} --version
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -75,14 +75,14 @@ jobs:
            sudo apt remove clang
            apt search ^clang
            sudo apt install ${{ matrix.compiler }}
-           #sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${{ matrix.compiler }} 50
-           #sudo update-alternatives --install /usr/bin/clang clang /usr/bin/${{ matrix.compiler }} 50
+           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/${{ matrix.compiler }} 50
+           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/${{ matrix.compiler }} 50
            #set CXX ${{ matrix.compiler }}
            ${{ matrix.compiler }} --version
 
     - name: Build
-      env:
-        CXX: ${{ matrix.compiler }}
+      #env:
+      #  CXX: ${{ matrix.compiler }}
       working-directory: ${{ github.workspace }}/Projects/Make
       run: make
 


### PR DESCRIPTION
Currently, we use the default Clang and GCC on the CI machines. This commit installs older versions, allowing us to maintain support for old compilers.