### PR TITLE
Add Exists check

### DIFF
--- a/Code/max/Compiling/Exists.hpp
+++ b/Code/max/Compiling/Exists.hpp
@@ -1,0 +1,35 @@
+// Copyright 2023, The max Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MAX_COMPILING_EXISTS_HPP
+#define MAX_COMPILING_EXISTS_HPP
+
+#include <type_traits>
+
+namespace max
+{
+	namespace Compiling
+	{
+
+		template <class T, template <class...> class Test>
+		struct Exists
+		{
+			template<class U>
+			static std::true_type Check(Test<U>*);
+
+			template<class U>
+			static std::false_type Check(...);
+
+			static constexpr bool value = decltype(Check<T>(0))::value;
+		};
+
+		// Usage:
+		// template<class U, class = decltype(U::MemberFunctionNameHere())>
+		// struct MemberFunctionNameHereTest{};
+		// if constexpr (max::Compiling::Exists<ClassHere, MemberFunctionNameHereTest>::value) { ... }
+
+	} // namespace Compiling
+} // namespace max
+
+#endif // #ifndef MAX_COMPILING_EXISTS_HPP


### PR DESCRIPTION
This commit adds max::Compiling::Exists, which allows code to change behavior based on whether a member function exists. This is useful for a pre-concepts era when functions are expected to exist. It also allows a form of optional concepts.