### PR TITLE
Add MakeRectangle

### DIFF
--- a/Code/max/Containers/Rectangle.hpp
+++ b/Code/max/Containers/Rectangle.hpp
@@ -32,6 +32,9 @@ namespace Containers
 
 	};
 
+	template< typename PointOrdinateType, typename LengthType >
+	Rectangle< PointOrdinateType, LengthType > MakeRectangle( PointOrdinateType left, PointOrdinateType top, LengthType width, LengthType height ) noexcept;
+
 } // namespace Containers
 } // MAX_CURRENT_VERSION_NAMESPACE_BEGIN( v0 )
 MAX_CURRENT_VERSION_NAMESPACE_END( v0 )

--- a/Code/max/Containers/Rectangle.inl
+++ b/Code/max/Containers/Rectangle.inl
@@ -18,6 +18,11 @@ namespace Containers
 		, Height(std::move(Height))
 	{}
 
+	template< typename PointOrdinateType, typename LengthType >
+	Rectangle< PointOrdinateType, LengthType > MakeRectangle( PointOrdinateType left, PointOrdinateType top, LengthType width, LengthType height ) noexcept {
+		return Rectangle( CartesianPoint< PointOrdinateType, 2 >{ left, top }, width, height );
+	}
+
 } // namespace Containers
 } // namespace v0
 } // namespace max


### PR DESCRIPTION
Currently, creating a rectangle also requires creating a CartesianPoint of dimension 2. It becomes unweildly.

This commit adds a MakeRectangle function which simplifies the usage of Rectangle.