### PR TITLE
Update MSVC to 17.7

### DIFF
--- a/Code/max/Compiling/Configuration/Compiler/VC.hpp
+++ b/Code/max/Compiling/Configuration/Compiler/VC.hpp
@@ -11,8 +11,12 @@
 
 #define MAX_COMPILER_MESSAGE( Message ) __pragma( message( Message ) )
 
-#if _MSC_VER > 1936
+#if _MSC_VER > 1937
 	MAX_COMPILER_MESSAGE( "Compiling with a newer version of MSVC than max recognizes. Using last known version." );
+#elif _MSC_VER >= 1937
+	// MSVC++ (Visual Studio 2022 / version 17.7)
+	#define MAX_COMPILER_VERSION_MAJOR 17
+	#define MAX_COMPILER_VERSION_MINOR 7
 #elif _MSC_VER >= 1936
 	// MSVC++ (Visual Studio 2022 / version 17.6)
 	#define MAX_COMPILER_VERSION_MAJOR 17

--- a/Docs/DeprecationSchedule.md
+++ b/Docs/DeprecationSchedule.md
@@ -40,7 +40,8 @@
 
 |MSVC version      |Release date|max deprecation date|Adds support for                                    |
 |------------------|-----------:|-------------------:|----------------------------------------------------|
-|MSVC 17.6.x       |May 16, 2023|             Current|                                                    |
+|MSVC 17.7.x       |Aug  8, 2023|             Current|                                                    |
+|MSVC 17.6.x       |May 16, 2023|        Aug  8, 2028|                                                    |
 |MSVC 17.5.x       |Feb 21, 2023|        May 16, 2028|                                                    |
 |MSVC 17.4.x       |Nov 15, 2022|        Feb 21, 2028|<stacktrace>                                        |
 |MSVC 17.3.x       |Aug  9, 2022|        Nov 15, 2027|<expected>                                          |


### PR DESCRIPTION
MSVC 17.7 was released. Update the known compilers list and deprecation schedule.