### PR TITLE
std::swapendian is now within minimum support. Use it instead of our …

### DIFF
--- a/Code/max/Algorithms/SwapEndian.hpp
+++ b/Code/max/Algorithms/SwapEndian.hpp
@@ -8,6 +8,7 @@
 #include <max/Compiling/CurrentVersionNamespace.hpp>
 #include <max/Compiling/AliasingOptimizations.hpp>
 #include <cstdint>
+#include <concepts>
 
 namespace max
 {
@@ -16,47 +17,17 @@ MAX_CURRENT_VERSION_NAMESPACE_BEGIN( v0 )
 namespace Algorithms
 {
 
-	MAX_PURE_DECLARATION( inline uint64_t SwapEndian( const uint64_t Value ) noexcept );
-	MAX_PURE_DECLARATION( inline uint32_t SwapEndian( const uint32_t Value ) noexcept );
-	MAX_PURE_DECLARATION( inline uint16_t SwapEndian( const uint16_t Value ) noexcept );
-	MAX_PURE_DECLARATION( inline int64_t  SwapEndian( const int64_t  Value ) noexcept );
-	MAX_PURE_DECLARATION( inline int32_t  SwapEndian( const int32_t  Value ) noexcept );
-	MAX_PURE_DECLARATION( inline int16_t  SwapEndian( const int16_t  Value ) noexcept );
+	template <std::integral T>
+	MAX_PURE_DECLARATION( constexpr inline T LittleEndianToHost(const T Value ) noexcept );
 
-	MAX_PURE_DECLARATION( constexpr inline uint64_t SwapEndianConstexpr( const uint64_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline uint32_t SwapEndianConstexpr( const uint32_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline uint16_t SwapEndianConstexpr( const uint16_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int64_t  SwapEndianConstexpr( const int64_t  Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int32_t  SwapEndianConstexpr( const int32_t  Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int16_t  SwapEndianConstexpr( const int16_t  Value ) noexcept );
+	template <std::integral T>
+	MAX_PURE_DECLARATION( constexpr inline T BigEndianToHost( const T Value ) noexcept );
 
-	MAX_PURE_DECLARATION( constexpr inline uint64_t LittleEndianToHost( const uint64_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline uint32_t LittleEndianToHost( const uint32_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline uint16_t LittleEndianToHost( const uint16_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int64_t  LittleEndianToHost( const int64_t  Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int32_t  LittleEndianToHost( const int32_t  Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int16_t  LittleEndianToHost( const int16_t  Value ) noexcept );
+	template <std::integral T>
+	MAX_PURE_DECLARATION( constexpr inline T HostToLittleEndian( const T Value ) noexcept );
 
-	MAX_PURE_DECLARATION( constexpr inline uint64_t BigEndianToHost( const uint64_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline uint32_t BigEndianToHost( const uint32_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline uint16_t BigEndianToHost( const uint16_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int64_t  BigEndianToHost( const int64_t  Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int32_t  BigEndianToHost( const int32_t  Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int16_t  BigEndianToHost( const int16_t  Value ) noexcept );
-
-	MAX_PURE_DECLARATION( constexpr inline uint64_t HostToLittleEndian( const uint64_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline uint32_t HostToLittleEndian( const uint32_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline uint16_t HostToLittleEndian( const uint16_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int64_t  HostToLittleEndian( const int64_t  Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int32_t  HostToLittleEndian( const int32_t  Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int16_t  HostToLittleEndian( const int16_t  Value ) noexcept );
-
-	MAX_PURE_DECLARATION( constexpr inline uint64_t HostToBigEndian( const uint64_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline uint32_t HostToBigEndian( const uint32_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline uint16_t HostToBigEndian( const uint16_t Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int64_t  HostToBigEndian( const int64_t  Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int32_t  HostToBigEndian( const int32_t  Value ) noexcept );
-	MAX_PURE_DECLARATION( constexpr inline int16_t  HosttoBigEndian( const int16_t  Value ) noexcept );
+	template <std::integral T>
+	MAX_PURE_DECLARATION( constexpr inline T HostToBigEndian( const T Value ) noexcept );
 
 	MAX_PURE_DECLARATION( constexpr inline uint64_t CombinePieces( const uint8_t First8Bits,
 	                                                               const uint8_t Second8Bits,

--- a/Code/max/Algorithms/SwapEndian.inl
+++ b/Code/max/Algorithms/SwapEndian.inl
@@ -7,6 +7,7 @@
 #if defined( MAX_COMPILER_VC )
 #include <stdlib.h>
 #endif
+#include <bit>
 
 namespace max
 {
@@ -15,373 +16,60 @@ namespace v0
 namespace Algorithms
 {
 
-#if defined( MAX_COMPILER_CLANG ) || \
-	( defined( MAX_COMPILER_GCC ) && MAX_COMPILER_VERSION_AT_LEAST( 4, 3, 0 )  )
-	MAX_PURE_DEFINITION( inline uint64_t SwapEndian( const uint64_t Value ) noexcept )
+	template < std::integral T >
+	MAX_PURE_DEFINITION( constexpr inline T LittleEndianToHost( const T Value ) noexcept )
 	{
-		return __builtin_bswap64( Value );
-	}
+		static_assert( std::endian::native == std::endian::little ||
+		               std::endian::native == std::endian::big,
+		               "Unknown endianness" );
 
-	MAX_PURE_DEFINITION( inline uint32_t SwapEndian( const uint32_t Value ) noexcept )
-	{
-		return __builtin_bswap32( Value );
-	}
-
-	MAX_PURE_DEFINITION( inline uint16_t SwapEndian( const uint16_t Value ) noexcept )
-	{
-		return __builtin_bswap16( Value );
-	}
-#elif defined( MAX_COMPILER_VC )
-	MAX_PURE_DEFINITION( inline uint64_t SwapEndian( const uint64_t Value ) noexcept )
-	{
-		return _byteswap_uint64( Value );
-	}
-
-	MAX_PURE_DEFINITION( inline uint32_t SwapEndian( const uint32_t Value ) noexcept )
-	{
-		return _byteswap_ulong( Value );
-	}
-
-	MAX_PURE_DEFINITION( inline uint16_t SwapEndian( const uint16_t Value ) noexcept )
-	{
-		return _byteswap_ushort( Value );
-	}
-#else
-	MAX_PURE_DEFINITION( inline uint64_t SwapEndian( const uint64_t Value ) noexcept )
-	{
-		return static_cast< const uint64_t >(
-			( ( Value & 0xff00'0000'0000'0000ull ) >> 56 ) |  // move byte 7 to byte 0
-			( ( Value & 0x00ff'0000'0000'0000ull ) >> 40 ) |  // move byte 6 to byte 1
-			( ( Value & 0x0000'ff00'0000'0000ull ) >> 24 ) |  // move byte 5 to byte 2
-			( ( Value & 0x0000'00ff'0000'0000ull ) >> 8  ) |  // move byte 4 to byte 3
-			( ( Value & 0x0000'0000'ff00'0000ull ) << 8  ) |  // move byte 3 to byte 4
-			( ( Value & 0x0000'0000'00ff'0000ull ) << 24 ) |  // move byte 2 to byte 5
-			( ( Value & 0x0000'0000'0000'ff00ull ) << 40 ) |  // move byte 1 to byte 6
-			( ( Value & 0x0000'0000'0000'00ffull ) << 56 ) ); // move byte 0 to byte 7
-	}
-
-	MAX_PURE_DEFINITION( inline uint32_t SwapEndian( const uint32_t Value ) noexcept )
-	{
-		return static_cast< const uint32_t >(
-			( ( Value & 0xff000000 ) >> 24 ) |  // move byte 3 to byte 0
-			( ( Value & 0x00ff0000 ) >> 8  ) |  // move byte 2 to byte 1
-			( ( Value & 0x0000ff00 ) << 8  ) |  // move byte 1 to byte 2
-			( ( Value & 0x000000ff ) << 24 ) ); // move byte 0 to byte 3
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint16_t SwapEndian( const uint16_t Value ) noexcept )
-	{
-		return static_cast< const uint16_t >(
-			( ( Value & 0xff00 ) >> 8 ) |
-			( ( Value & 0x00ff ) << 8 ) );
-	}
-#endif
-
-	MAX_PURE_DEFINITION( inline int64_t SwapEndian( const int64_t Value ) noexcept )
-	{
-		return static_cast< int64_t >(
-			SwapEndian( static_cast< uint64_t >( Value ) )
-		);
-	}
-
-	MAX_PURE_DEFINITION( inline int32_t SwapEndian( const int32_t Value ) noexcept )
-	{
-		return static_cast< int32_t >(
-			SwapEndian( static_cast< uint32_t >( Value ) )
-		);
-	}
-
-	MAX_PURE_DEFINITION( inline int16_t SwapEndian( const int16_t Value ) noexcept )
-	{
-		return static_cast< int16_t >(
-			SwapEndian( static_cast< uint16_t >( Value ) )
-		);
-	}
-
-#if defined( MAX_COMPILER_CLANG ) || \
-	( defined( MAX_COMPILER_GCC ) && MAX_COMPILER_VERSION_AT_LEAST( 4, 3, 0 )  )
-	MAX_PURE_DEFINITION( constexpr inline uint64_t SwapEndianConstexpr( const uint64_t Value ) noexcept )
-	{
-		return __builtin_bswap64( Value );
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint32_t SwapEndianConstexpr( const uint32_t Value ) noexcept )
-	{
-		return __builtin_bswap32( Value );
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint16_t SwapEndianConstexpr( const uint16_t Value ) noexcept )
-	{
-		return __builtin_bswap16( Value );
-	}
-#else
-	// MSVC does not allow intrinsics inside a constexpr. So use the normal functions.
-
-	MAX_PURE_DEFINITION( constexpr inline uint64_t SwapEndianConstexpr( const uint64_t Value ) noexcept )
-	{
-		return static_cast<const uint64_t>(
-			( ( Value & 0xff00'0000'0000'0000ull ) >> 56 ) |  // move byte 7 to byte 0
-			( ( Value & 0x00ff'0000'0000'0000ull ) >> 40 ) |  // move byte 6 to byte 1
-			( ( Value & 0x0000'ff00'0000'0000ull ) >> 24 ) |  // move byte 5 to byte 2
-			( ( Value & 0x0000'00ff'0000'0000ull ) >> 8  ) |  // move byte 4 to byte 3
-			( ( Value & 0x0000'0000'ff00'0000ull ) << 8  ) |  // move byte 3 to byte 4
-			( ( Value & 0x0000'0000'00ff'0000ull ) << 24 ) |  // move byte 2 to byte 5
-			( ( Value & 0x0000'0000'0000'ff00ull ) << 40 ) |  // move byte 1 to byte 6
-			( ( Value & 0x0000'0000'0000'00ffull ) << 56 ) ); // move byte 0 to byte 7
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint32_t SwapEndianConstexpr( const uint32_t Value ) noexcept )
-	{
-		return static_cast< const uint32_t >(
-			( ( Value & 0xff000000 ) >> 24 ) |  // move byte 3 to byte 0
-			( ( Value & 0x00ff0000 ) >> 8  ) |  // move byte 2 to byte 1
-			( ( Value & 0x0000ff00 ) << 8  ) |  // move byte 1 to byte 2
-			( ( Value & 0x000000ff ) << 24 ) ); // move byte 0 to byte 3
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint16_t SwapEndianConstexpr( const uint16_t Value ) noexcept )
-	{
-		return static_cast< const uint16_t >(
-			( ( Value & 0xff00 ) >> 8 ) |
-			( ( Value & 0x00ff ) << 8 ) );
-	}
-#endif
-
-	MAX_PURE_DEFINITION( constexpr inline int64_t SwapEndianConstexpr( const int64_t Value ) noexcept )
-	{
-		return static_cast< int64_t >(
-			SwapEndianConstexpr( static_cast< uint64_t >( Value ) )
-			);
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline int32_t SwapEndianConstexpr( const int32_t Value ) noexcept )
-	{
-		return static_cast< int32_t >(
-			SwapEndianConstexpr( static_cast< uint32_t >( Value ) )
-			);
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline int16_t SwapEndianConstexpr( const int16_t Value ) noexcept )
-	{
-		return static_cast< int16_t >(
-			SwapEndianConstexpr( static_cast< uint16_t >( Value ) )
-			);
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint64_t LittleEndianToHost( const uint64_t Value ) noexcept )
-	{
-		#if defined( MAX_LITTLE_ENDIAN )
+		if constexpr ( std::endian::native == std::endian::little ) {
 			return Value;
-		#elif defined( MAX_BIG_ENDIAN )
-			return SwapEndian( Value );
-		#else
-			static_assert( false, "Unknown endianness" );
-		#endif
+		} else if constexpr ( std::endian::native == std::endian::big ) {
+			return std::byteswap( Value );
+		}
 	}
 
-	MAX_PURE_DEFINITION( constexpr inline uint32_t LittleEndianToHost( const uint32_t Value ) noexcept )
+	template < std::integral T >
+	MAX_PURE_DEFINITION( constexpr inline T BigEndianToHost( const T Value ) noexcept )
 	{
-		#if defined( MAX_LITTLE_ENDIAN )
+		static_assert( std::endian::native == std::endian::little ||
+		               std::endian::native == std::endian::big,
+		               "Unknown endianness" );
+
+		if constexpr ( std::endian::native == std::endian::big ) {
 			return Value;
-		#elif defined( MAX_BIG_ENDIAN )
-			return SwapEndian( Value );
-		#else
-			static_assert( false, "Unknown endianness" );
-		#endif
+		} else if constexpr ( std::endian::native == std::endian::little ) {
+			return std::byteswap( Value );
+		}
 	}
 
-	MAX_PURE_DEFINITION( constexpr inline uint16_t LittleEndianToHost( const uint16_t Value ) noexcept )
+	template < std::integral T >
+	MAX_PURE_DEFINITION( constexpr inline T HostToLittleEndian( const T Value ) noexcept )
 	{
-		#if defined( MAX_LITTLE_ENDIAN )
+		static_assert( std::endian::native == std::endian::little ||
+		               std::endian::native == std::endian::big,
+		               "Unknown endianness" );
+
+		if constexpr ( std::endian::native == std::endian::little ) {
 			return Value;
-		#elif defined( MAX_BIG_ENDIAN )
-			return SwapEndian( Value );
-		#else
-			static_assert( false, "Unknown endianness" );
-		#endif
+		} else if constexpr ( std::endian::native == std::endian::big ) {
+			return std::byteswap( Value );
+		}
 	}
 
-	MAX_PURE_DEFINITION( constexpr inline int64_t LittleEndianToHost( const int64_t Value ) noexcept )
+	template < std::integral T >
+	MAX_PURE_DEFINITION( constexpr inline T HostToBigEndian( const T Value ) noexcept )
 	{
-		return static_cast< int64_t >(
-			LittleEndianToHost( static_cast< uint64_t >( Value ) )
-		);
-	}
+		static_assert( std::endian::native == std::endian::little ||
+		               std::endian::native == std::endian::big,
+		               "Unknown endianness" );
 
-	MAX_PURE_DEFINITION( constexpr inline int32_t LittleEndianToHost( const int32_t Value ) noexcept )
-	{
-		return static_cast< int32_t >(
-			LittleEndianToHost( static_cast< uint32_t >( Value ) )
-		);
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline int16_t LittleEndianToHost( const int16_t Value ) noexcept )
-	{
-		return static_cast< int16_t >(
-			LittleEndianToHost( static_cast< uint16_t >( Value ) )
-		);
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint64_t BigEndianToHost( const uint64_t Value ) noexcept )
-	{
-		#if defined( MAX_BIG_ENDIAN )
+		if constexpr ( std::endian::native == std::endian::big ) {
 			return Value;
-		#elif defined( MAX_LITTLE_ENDIAN )
-			return SwapEndianConstexpr( Value );
-		#else
-			static_assert( false, "Unknown endianness" );
-		#endif
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint32_t BigEndianToHost( const uint32_t Value ) noexcept )
-	{
-		#if defined( MAX_BIG_ENDIAN )
-			return Value;
-		#elif defined( MAX_LITTLE_ENDIAN )
-			return SwapEndianConstexpr( Value );
-		#else
-			static_assert( false, "Unknown endianness" );
-		#endif
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint16_t BigEndianToHost( const uint16_t Value ) noexcept )
-	{
-		#if defined( MAX_BIG_ENDIAN )
-			return Value;
-		#elif defined( MAX_LITTLE_ENDIAN )
-			return SwapEndianConstexpr( Value );
-		#else
-			static_assert( false, "Unknown endianness" );
-		#endif
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline int64_t BigEndianToHost( const int64_t Value ) noexcept )
-	{
-		return static_cast< int64_t >(
-			BigEndianToHost( static_cast< uint64_t >( Value ) )
-		);
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline int32_t BigEndianToHost( const int32_t Value ) noexcept )
-	{
-		return static_cast< int32_t >(
-			BigEndianToHost( static_cast< uint32_t >( Value ) )
-		);
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline int16_t BigEndianToHost( const int16_t Value ) noexcept )
-	{
-		return static_cast< int16_t >(
-			BigEndianToHost( static_cast< uint16_t >( Value ) )
-		);
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint64_t HostToLittleEndian( const uint64_t Value ) noexcept )
-	{
-		#if defined( MAX_LITTLE_ENDIAN )
-			return Value;
-		#elif defined( MAX_BIG_ENDIAN )
-			return SwapEndian( Value );
-		#else
-			static_assert( false, "Unknown endianness" );
-		#endif
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint32_t HostToLittleEndian( const uint32_t Value ) noexcept )
-	{
-		#if defined( MAX_LITTLE_ENDIAN )
-			return Value;
-		#elif defined( MAX_BIG_ENDIAN )
-			return SwapEndian( Value );
-		#else
-			static_assert( false, "Unknown endianness" );
-		#endif
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint16_t HostToLittleEndian( const uint16_t Value ) noexcept )
-	{
-		#if defined( MAX_LITTLE_ENDIAN )
-			return Value;
-		#elif defined( MAX_BIG_ENDIAN )
-			return SwapEndian( Value );
-		#else
-			static_assert( false, "Unknown endianness" );
-		#endif
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline int64_t HostToLittleEndian( const int64_t Value ) noexcept )
-	{
-		return static_cast< int64_t >(
-			HostToLittleEndian( static_cast< uint64_t >( Value ) )
-		);
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline int32_t HostToLittleEndian( const int32_t Value ) noexcept )
-	{
-		return static_cast< int32_t >(
-			HostToLittleEndian( static_cast< uint32_t >( Value ) )
-		);
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline int16_t HostToLittleEndian( const int16_t Value ) noexcept )
-	{
-		return static_cast< int16_t >(
-			HostToLittleEndian( static_cast< uint16_t >( Value ) )
-		);
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint64_t HostToBigEndian( const uint64_t Value ) noexcept )
-	{
-		#if defined( MAX_BIG_ENDIAN )
-			return Value;
-		#elif defined( MAX_LITTLE_ENDIAN )
-			return SwapEndianConstexpr( Value );
-		#else
-			static_assert( false, "Unknown endianness" );
-		#endif
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint32_t HostToBigEndian( const uint32_t Value ) noexcept )
-	{
-		#if defined( MAX_BIG_ENDIAN )
-			return Value;
-		#elif defined( MAX_LITTLE_ENDIAN )
-			return SwapEndianConstexpr( Value );
-		#else
-			static_assert( false, "Unknown endianness" );
-		#endif
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline uint16_t HostToBigEndian( const uint16_t Value ) noexcept )
-	{
-		#if defined( MAX_BIG_ENDIAN )
-			return Value;
-		#elif defined( MAX_LITTLE_ENDIAN )
-			return SwapEndianConstexpr( Value );
-		#else
-			static_assert( false, "Unknown endianness" );
-		#endif
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline int64_t HostToBigEndian( const int64_t Value ) noexcept )
-	{
-		return static_cast< int64_t >(
-			HostToBigEndian( static_cast< uint64_t >( Value ) )
-		);
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline int32_t HostToBigEndian( const int32_t Value ) noexcept )
-	{
-		return static_cast< int32_t >(
-			HostToBigEndian( static_cast< uint32_t >( Value ) )
-		);
-	}
-
-	MAX_PURE_DEFINITION( constexpr inline int16_t HostToBigEndian( int16_t Value ) noexcept )
-	{
-		return static_cast< int16_t >(
-			HostToBigEndian( static_cast< uint16_t >( Value ) )
-		);
+		} else if constexpr ( std::endian::native == std::endian::little ) {
+			return std::byteswap( Value );
+		}
 	}
 
 	MAX_PURE_DEFINITION( constexpr inline uint64_t CombinePieces( const uint8_t First8Bits,

--- a/Code/max/Algorithms/SwapEndianTest.cpp
+++ b/Code/max/Algorithms/SwapEndianTest.cpp
@@ -15,36 +15,8 @@ namespace maxAutomatedTests
 
 		void RunSwapEndianTestSuite()
 		{
-			static_assert( max::Algorithms::SwapEndianConstexpr( uint64_t{ 0x1234567890abcdef } ) == uint64_t{ 0xefcdab9078563412 }, "max::Algorithms::SwapEndianConstexpr( uint64_t ) isn't swapping endian correctly." );
-			static_assert( max::Algorithms::SwapEndianConstexpr( uint32_t{ 0x12345678         } ) == uint32_t{ 0x78563412         }, "max::Algorithms::SwapEndianConstexpr( uint32_t ) isn't swapping endian correctly." );
-			static_assert( max::Algorithms::SwapEndianConstexpr( uint16_t{ 0x1234             } ) == uint16_t{ 0x3412             }, "max::Algorithms::SwapEndianConstexpr( uint16_t ) isn't swapping endian correctly." );
-			static_assert( max::Algorithms::SwapEndianConstexpr(  int64_t{ 0x1234567890abcd00 } ) ==  int64_t{ 0x00cdab9078563412 }, "max::Algorithms::SwapEndianConstexpr( int64_t ) isn't swapping endian correctly."  );
-			static_assert( max::Algorithms::SwapEndianConstexpr(  int32_t{ 0x12345678         } ) ==  int32_t{ 0x78563412         }, "max::Algorithms::SwapEndianConstexpr( int32_t ) isn't swapping endian correctly."  );
-			static_assert( max::Algorithms::SwapEndianConstexpr(  int16_t{ 0x1234             } ) ==  int16_t{ 0x3412             }, "max::Algorithms::SwapEndianConstexpr( int16_t ) isn't swapping endian correctly."  );
-
 			max::Testing::CoutResultPolicy ResultPolicy;
 			auto SwapEndianTestSuite = max::Testing::TestSuite< max::Testing::CoutResultPolicy >{ "max::Algorithms::SwapEndian test suite", std::move( ResultPolicy ) };
-
-			SwapEndianTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "SwapEndian", []( max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy ) {
-				uint64_t Unsigned64BitValue = UINT64_C( 0x1234567890abcdef );
-				CurrentTest.MAX_TESTING_ASSERT( max::Algorithms::SwapEndian( Unsigned64BitValue ) == uint64_t{ 0xefcdab9078563412 } );
-
-				uint32_t Unsigned32BitValue = UINT32_C( 0x12345678 );
-				CurrentTest.MAX_TESTING_ASSERT( max::Algorithms::SwapEndian( Unsigned32BitValue ) == uint32_t{ 0x78563412 } );
-
-				uint16_t Unsigned16BitValue = UINT16_C( 0x1234 );
-				CurrentTest.MAX_TESTING_ASSERT( max::Algorithms::SwapEndian( Unsigned16BitValue ) == uint16_t{ 0x3412 } );
-
-				int64_t Signed64BitValue = INT64_C( 0x1234567890abcdef );
-				CurrentTest.MAX_TESTING_ASSERT( max::Algorithms::SwapEndian( Signed64BitValue ) == static_cast< int64_t >( 0xefcdab9078563412 ) );
-
-				int32_t Signed32BitValue = INT32_C( 0x12345678 );
-				CurrentTest.MAX_TESTING_ASSERT( max::Algorithms::SwapEndian( Signed32BitValue ) == int32_t{ 0x78563412 } );
-
-				int16_t Signed16BitValue = UINT16_C( 0x1234 );
-				CurrentTest.MAX_TESTING_ASSERT( max::Algorithms::SwapEndian( Signed16BitValue ) == int16_t{ 0x3412 } );
-				}
-			});
 
 			// TODO: Add LittleEndianToHost test
 			// TODO: Add BigEndianToHost test

--- a/Projects/Make/Makefile
+++ b/Projects/Make/Makefile
@@ -91,7 +91,7 @@ else
 	TARGET_BIT_FLAG = -m32
 endif
 
-CPPFLAGS += $(INCLUDE_PATHS_FLAGS) -std=c++17 -Werror -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion $(TARGET_BIT_FLAG)
+CPPFLAGS += $(INCLUDE_PATHS_FLAGS) -std=c++23 -Werror -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion $(TARGET_BIT_FLAG)
 LINKER_FLAGS += $(LIBRARY_PATHS_FLAGS)
 
 


### PR DESCRIPTION
…own custom implementation